### PR TITLE
Fix readrpl temp zlib buffer size

### DIFF
--- a/tools/readrpl/main.cpp
+++ b/tools/readrpl/main.cpp
@@ -591,7 +591,7 @@ bool readSection(std::ifstream &fh, elf::SectionHeader &header, std::vector<char
          return false;
       } else {
          std::vector<char> temp;
-         temp.resize(header.size);
+         temp.resize(header.size-sizeof(uint32_t));
          fh.read(temp.data(), temp.size());
 
          stream.avail_in = header.size;


### PR DESCRIPTION
header.size includes the u32 decompressed size, which is read earlier. When an rpx (such as safe.rpx from Heath and Safety) with zlib compressed data at the very end is read, the inputstream will attempt to read past the end of the file and then error silently and no longer read, usually causing a segfault due to a null pointer for shStrTab.