### PR TITLE
Remove imports which don't exist in elf2rpl's target coreinit version

### DIFF
--- a/include/coreinit/expandedheap.h
+++ b/include/coreinit/expandedheap.h
@@ -31,19 +31,10 @@ typedef enum MEMExpHeapDirection
 } MEMExpHeapDirection;
 
 MEMExpandedHeap *
-MEMCreateExpHeap(MEMExpandedHeap *heap, uint32_t size);
-
-MEMExpandedHeap *
 MEMCreateExpHeapEx(MEMExpandedHeap *heap, uint32_t size, uint16_t flags);
 
 MEMExpandedHeap *
 MEMDestroyExpHeap(MEMExpandedHeap *heap);
-
-void
-MEMiDumpExpHeap(MEMExpandedHeap *heap);
-
-void *
-MEMAllocFromExpHeap(MEMExpandedHeap *heap, uint32_t size);
 
 void *
 MEMAllocFromExpHeapEx(MEMExpandedHeap *heap, uint32_t size, int alignment);
@@ -65,9 +56,6 @@ MEMResizeForMBlockExpHeap(MEMExpandedHeap *heap, uint8_t *address, uint32_t size
 
 uint32_t
 MEMGetTotalFreeSizeForExpHeap(MEMExpandedHeap *heap);
-
-uint32_t
-MEMGetAllocatableSizeForExpHeap(MEMExpandedHeap *heap);
 
 uint32_t
 MEMGetAllocatableSizeForExpHeapEx(MEMExpandedHeap *heap, int alignment);

--- a/include/coreinit/frameheap.h
+++ b/include/coreinit/frameheap.h
@@ -25,20 +25,12 @@ struct MEMFrameHeap
 UNKNOWN_SIZE(MEMFrameHeap);
 
 MEMFrameHeap *
-MEMCreateFrmHeap(MEMFrameHeap *heap,
-                 uint32_t size);
-
-MEMFrameHeap *
 MEMCreateFrmHeapEx(MEMFrameHeap *heap,
                    uint32_t size,
                    uint16_t flags);
 
 void *
 MEMDestroyFrmHeap(MEMFrameHeap *heap);
-
-void *
-MEMAllocFromFrmHeap(MEMFrameHeap *heap,
-                    uint32_t size);
 
 void *
 MEMAllocFromFrmHeapEx(MEMFrameHeap *heap,
@@ -64,9 +56,6 @@ uint32_t
 MEMResizeForMBlockFrmHeap(MEMFrameHeap *heap,
                           uint32_t addr,
                           uint32_t size);
-
-uint32_t
-MEMGetAllocatableSizeForFrmHeap(MEMFrameHeap *heap);
 
 uint32_t
 MEMGetAllocatableSizeForFrmHeapEx(MEMFrameHeap *heap,

--- a/include/coreinit/messagequeue.h
+++ b/include/coreinit/messagequeue.h
@@ -70,11 +70,6 @@ OSSendMessage(OSMessageQueue *queue,
               OSMessageFlags flags);
 
 BOOL
-OSJamMessage(OSMessageQueue *queue,
-             OSMessage *message,
-             OSMessageFlags flags);
-
-BOOL
 OSReceiveMessage(OSMessageQueue *queue,
                  OSMessage *message,
                  OSMessageFlags flags);

--- a/rpl/libcoreinit/exports.h
+++ b/rpl/libcoreinit/exports.h
@@ -88,11 +88,8 @@ EXPORT(exit);
 EXPORT(_Exit);
 
 // coreinit/expandedheap.h
-EXPORT(MEMCreateExpHeap);
 EXPORT(MEMCreateExpHeapEx);
 EXPORT(MEMDestroyExpHeap);
-EXPORT(MEMiDumpExpHeap);
-EXPORT(MEMAllocFromExpHeap);
 EXPORT(MEMAllocFromExpHeapEx);
 EXPORT(MEMFreeToExpHeap);
 EXPORT(MEMSetAllocModeForExpHeap);
@@ -100,7 +97,6 @@ EXPORT(MEMGetAllocModeForExpHeap);
 EXPORT(MEMAdjustExpHeap);
 EXPORT(MEMResizeForMBlockExpHeap);
 EXPORT(MEMGetTotalFreeSizeForExpHeap);
-EXPORT(MEMGetAllocatableSizeForExpHeap);
 EXPORT(MEMGetAllocatableSizeForExpHeapEx);
 EXPORT(MEMSetGroupIDForExpHeap);
 EXPORT(MEMGetGroupIDForExpHeap);
@@ -157,17 +153,14 @@ EXPORT(FSGetVolumeState);
 EXPORT(FSGetLastErrorCodeForViewer);
 
 // coreinit/frameheap.h
-EXPORT(MEMCreateFrmHeap);
 EXPORT(MEMCreateFrmHeapEx);
 EXPORT(MEMDestroyFrmHeap);
-EXPORT(MEMAllocFromFrmHeap);
 EXPORT(MEMAllocFromFrmHeapEx);
 EXPORT(MEMFreeToFrmHeap);
 EXPORT(MEMRecordStateForFrmHeap);
 EXPORT(MEMFreeByStateToFrmHeap);
 EXPORT(MEMAdjustFrmHeap);
 EXPORT(MEMResizeForMBlockFrmHeap);
-EXPORT(MEMGetAllocatableSizeForFrmHeap);
 EXPORT(MEMGetAllocatableSizeForFrmHeapEx);
 
 // coreinit/memlist.h
@@ -188,7 +181,6 @@ EXPORT(OSBlockSet);
 EXPORT(OSInitMessageQueue);
 EXPORT(OSInitMessageQueueEx);
 EXPORT(OSSendMessage);
-EXPORT(OSJamMessage);
 EXPORT(OSReceiveMessage);
 EXPORT(OSPeekMessage);
 EXPORT(OSGetSystemMessageQueue);
@@ -303,6 +295,5 @@ EXPORT(MEMCreateUnitHeapEx);
 EXPORT(MEMDestroyUnitHeap);
 EXPORT(MEMAllocFromUnitHeap);
 EXPORT(MEMFreeToUnitHeap);
-EXPORT(MEMiDumpUnitHeap);
 EXPORT(MEMCountFreeBlockForUnitHeap);
 EXPORT(MEMCalcHeapSizeForUnitHeap);


### PR DESCRIPTION
[These functions](https://gist.github.com/shinyquagsire23/14ee2d4272ce897340875964c17d5172) imported from wut do not exist in coreinit.rpl, as a result RPXs/RPLs with them in their imports will fail to load on hardware due to a check in loader.elf.