### PR TITLE
Fix corner case with findSymbol in elf2rpl

### DIFF
--- a/tools/elf2rpl/main.cpp
+++ b/tools/elf2rpl/main.cpp
@@ -90,6 +90,12 @@ static ElfFile::Symbol *
 findSymbol(ElfFile &file, uint32_t address)
 {
    for (auto &symbol : file.symbols) {
+      if (symbol->address == address && symbol->type != elf::STT_NOTYPE) {
+         return symbol.get();
+      }
+   }
+   
+   for (auto &symbol : file.symbols) {
       if (symbol->address == address) {
          return symbol.get();
       }


### PR DESCRIPTION
While reading symbols in relocations, findSymbol would sometimes select a symbol which ends up getting removed later on. By favoring symbols which will end up staying in the final RPL, this prevents that from happening.