### PR TITLE
Assume largest possible size increase after alignment for tempSize

### DIFF
--- a/tools/elf2rpl/main.cpp
+++ b/tools/elf2rpl/main.cpp
@@ -1014,7 +1014,7 @@ write(ElfFile &file, const std::string &filename)
             fileInfo.loadSize = val;
          }
       } else if (section->header.type == elf::SHT_RELA) {
-         fileInfo.tempSize += align_up(size, 64);
+         fileInfo.tempSize += (size + 128);
       }
    }
 


### PR DESCRIPTION
Another fix on tempSize...

Sometimes the offsets for RELA sections, while being aligned to 64, end up way larger than the predicted size. So the best solution is probably just to assume worst-case alignment, since loader.elf is perfectly fine with larger values, it just errors out on smaller ones.