### PR TITLE
Add OSScreen functions to coreinit

### DIFF
--- a/include/coreinit/screen.h
+++ b/include/coreinit/screen.h
@@ -1,0 +1,50 @@
+#pragma once
+#include <wut.h>
+
+/**
+ * \defgroup coreinit_screen Screen
+ * \ingroup coreinit
+ * @{
+ */
+ 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void 
+OSScreenInit();
+
+unsigned int 
+OSScreenGetBufferSizeEx(unsigned int bufferNum);
+
+int 
+OSScreenSetBufferEx(unsigned int bufferNum, void * addr);
+
+int 
+OSScreenClearBufferEx(unsigned int bufferNum, 
+                      unsigned int temp);
+
+int 
+OSScreenFlipBuffersEx(unsigned int bufferNum);
+
+int 
+OSScreenPutFontEx(unsigned int bufferNum, 
+                  unsigned int posX, 
+                  unsigned int posY, 
+                  const char * buffer);
+                  
+void 
+OSScreenPutPixelEx(int bufferNum, 
+                   uint32_t posX, 
+                   uint32_t posY, 
+                   uint32_t colour);
+
+int 
+OSScreenEnableEx(unsigned int bufferNum, 
+                 int enable);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/rpl/libcoreinit/exports.h
+++ b/rpl/libcoreinit/exports.h
@@ -203,6 +203,16 @@ EXPORT(OSInitRendezvous);
 EXPORT(OSWaitRendezvous);
 EXPORT(OSWaitRendezvousWithTimeout);
 
+// coreinit/screen.h
+EXPORT(OSScreenInit);
+EXPORT(OSScreenGetBufferSizeEx);
+EXPORT(OSScreenSetBufferEx);
+EXPORT(OSScreenClearBufferEx);
+EXPORT(OSScreenFlipBuffersEx);
+EXPORT(OSScreenPutFontEx);
+EXPORT(OSScreenPutPixelEx);
+EXPORT(OSScreenEnableEx);
+
 // coreinit/semaphore.h
 EXPORT(OSInitSemaphore);
 EXPORT(OSInitSemaphoreEx);


### PR DESCRIPTION
Basically what it says on the tin. OSScreen is useful for extremely basic homebrew since it can render fonts and give a straight framebuffer to work with.