### PR TITLE
Fix issue with import handling where import section symbols were indexed incorrectly

### DIFF
--- a/tools/elf2rpl/main.cpp
+++ b/tools/elf2rpl/main.cpp
@@ -561,7 +561,7 @@ getSectionIndex(std::vector<OutputSection *> &outSections, uint32_t address)
       auto start = section->header.addr;
       auto end = start + section->header.size;
 
-      if (address >= start && address <= end) {
+      if (address >= start && address < end) {
          return i;
       }
    }


### PR DESCRIPTION
Issue only seemed to occur when importing multiple RPLs