### PR TITLE
Add multitasking  support for wut

### DIFF
--- a/include/coreinit/foreground.h
+++ b/include/coreinit/foreground.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <wut.h>
+
+/**
+ * \defgroup coreinit_foreground Foreground Management
+ * \ingroup coreinit
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void
+OSEnableForegroundExit();
+
+void
+OSReleaseForeground();
+
+void
+OSSavesDone_ReadyToRelease();
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/include/proc_ui/procui.h
+++ b/include/proc_ui/procui.h
@@ -1,0 +1,68 @@
+#pragma once
+#include <wut.h>
+
+/**
+ * \defgroup proc_ui_procui ProcUI
+ * \ingroup proc_ui
+ * @{
+ */
+
+#ifdef __cplusplus
+"C" {
+#endif
+
+typedef void (*ProcUISaveCallback)(void);
+typedef uint32_t (*ProcUISaveCallbackEx)(void*);
+typedef uint32_t (*ProcUICallback)(void*);
+
+typedef enum ProcUIStatus
+{
+   PROCUI_STATUS_IN_FOREGROUND,
+   PROCUI_STATUS_IN_BACKGROUND,
+   PROCUI_STATUS_RELEASE_FOREGROUND,
+   PROCUI_STATUS_EXITING,
+} ProcUIStatus;
+
+uint32_t
+ProcUICalcMemorySize(uint32_t unk);
+
+void
+ProcUIClearCallbacks();
+
+void
+ProcUIDrawDoneRelease();
+
+BOOL
+ProcUIInForeground();
+
+BOOL
+ProcUIInShutdown();
+
+void
+ProcUIInit(ProcUISaveCallback saveCallback);
+
+void
+ProcUIInitEx(ProcUISaveCallbackEx saveCallback,
+             void *arg);
+
+BOOL
+ProcUIIsRunning();
+
+ProcUIStatus
+ProcUIProcessMessages(BOOL block);
+
+void
+ProcUISetSaveCallback(ProcUISaveCallbackEx saveCallback,
+                      void *arg);
+
+void
+ProcUIShutdown();
+
+ProcUIStatus
+ProcUISubProcessMessages();
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/rpl/Makefile
+++ b/rpl/Makefile
@@ -1,5 +1,5 @@
 WUT_ROOT := $(CURDIR)/..
-TARGETS := libcoreinit libgx2 libnsysnet libvpad libsysapp
+TARGETS := libcoreinit libgx2 libnsysnet libvpad libsysapp libproc_ui
 
 all:
 	@for dir in $(TARGETS); do \

--- a/rpl/libcoreinit/exports.h
+++ b/rpl/libcoreinit/exports.h
@@ -152,6 +152,11 @@ EXPORT(FSSetPosFileAsync);
 EXPORT(FSGetVolumeState);
 EXPORT(FSGetLastErrorCodeForViewer);
 
+// coreinit/foreground.h
+EXPORT(OSEnableForegroundExit);
+EXPORT(OSReleaseForeground);
+EXPORT(OSSavesDone_ReadyToRelease);
+
 // coreinit/frameheap.h
 EXPORT(MEMCreateFrmHeapEx);
 EXPORT(MEMDestroyFrmHeap);

--- a/rpl/libproc_ui/Makefile
+++ b/rpl/libproc_ui/Makefile
@@ -1,0 +1,2 @@
+-include ../common/rules.mk
+-include ../../common/rules.mk

--- a/rpl/libproc_ui/config.h
+++ b/rpl/libproc_ui/config.h
@@ -1,0 +1,1 @@
+#define LIBRARY_NAME "proc_ui"

--- a/rpl/libproc_ui/exports.h
+++ b/rpl/libproc_ui/exports.h
@@ -1,0 +1,14 @@
+// procui/procui.h
+EXPORT(ProcUICalcMemorySize);
+EXPORT(ProcUIClearCallbacks);
+EXPORT(ProcUIDrawDoneRelease);
+EXPORT(ProcUIInForeground);
+EXPORT(ProcUIInShutdown);
+EXPORT(ProcUIInit);
+EXPORT(ProcUIInitEx);
+EXPORT(ProcUIIsRunning);
+EXPORT(ProcUIProcessMessages);
+EXPORT(ProcUISetSaveCallback);
+EXPORT(ProcUIShutdown);
+EXPORT(ProcUISubProcessMessages);
+


### PR DESCRIPTION
Adds additional imports for foreground management to libcoreinit, imports proc_ui.rpl for multitasking management. Some imports are missing due to being update to determine functionality/arguments. Required for #23 