### PR TITLE
Have helloworld sample exit immediately using sysapp

### DIFF
--- a/samples/helloworld/Makefile
+++ b/samples/helloworld/Makefile
@@ -18,7 +18,7 @@ BUILD    := build
 SOURCE   := src
 INCLUDE  := include
 DATA     := data
-LIBS     := -lcoreinit -lproc_ui
+LIBS     := -lcoreinit -lproc_ui -lsysapp
 
 CFLAGS   += -O2 -Wall -std=c11
 CXXFLAGS += -O2 -Wall

--- a/samples/helloworld/src/main.c
+++ b/samples/helloworld/src/main.c
@@ -3,6 +3,7 @@
 #include <coreinit/thread.h>
 #include <coreinit/foreground.h>
 #include <proc_ui/procui.h>
+#include <sysapp/launch.h>
 
 bool isAppRunning = true;
 
@@ -81,6 +82,10 @@ main(int argc, char **argv)
 
    OSReport("Core 0 thread returned %d", resultCore0);
    OSReport("Core 2 thread returned %d", resultCore2);
+   
+   // Sends messages for ProcUI to release foreground, exit
+   // and launch into the system menu immediately.
+   SYSLaunchMenu();
    
    while(AppRunning());
    return 0;


### PR DESCRIPTION
No real point in forcing the user to use the Home Button Menu to exit when the app isn't doing much. Also a good example on exiting and switching apps using sysapp.