### PR TITLE
Fix improper use of 'shell uname' in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ifeq ($(shell uname -o),Cygwin)
+ifeq (,findstring CYGWIN,$(shell uname))
 WUT_ROOT := $(shell cygpath -w ${CURDIR})
 else
 WUT_ROOT := $(CURDIR)

--- a/rpl/common/rules.mk
+++ b/rpl/common/rules.mk
@@ -1,6 +1,6 @@
 .SUFFIXES:
 
-ifeq ($(shell uname -o),Cygwin)
+ifeq (,findstring CYGWIN,$(shell uname))
 CUR_DIR := $(shell cygpath -w ${CURDIR})
 else
 CUR_DIR := $(CURDIR)

--- a/rules/ppc.mk
+++ b/rules/ppc.mk
@@ -1,4 +1,4 @@
-ifeq ($(shell uname -o),Cygwin)
+ifeq (,findstring CYGWIN,$(shell uname))
 WUT_ROOT := $(shell cygpath -w ${WUT_ROOT})
 else
 WUT_ROOT := $(WUT_ROOT)

--- a/samples/helloworld/Makefile
+++ b/samples/helloworld/Makefile
@@ -4,7 +4,7 @@ ifeq ($(strip $(WUT_ROOT)),)
 $(error "Please ensure WUT_ROOT is in your environment.")
 endif
 
-ifeq ($(shell uname -o),Cygwin)
+ifeq (,findstring CYGWIN,$(shell uname))
 ROOT := $(shell cygpath -w ${CURDIR})
 WUT_ROOT := $(shell cygpath -w ${WUT_ROOT})
 else

--- a/samples/pong/Makefile
+++ b/samples/pong/Makefile
@@ -4,7 +4,7 @@ ifeq ($(strip $(WUT_ROOT)),)
 $(error "Please ensure WUT_ROOT is in your environment.")
 endif
 
-ifeq ($(shell uname -o),Cygwin)
+ifeq (,findstring CYGWIN,$(shell uname))
 ROOT := $(shell cygpath -w ${CURDIR})
 WUT_ROOT := $(shell cygpath -w ${WUT_ROOT})
 else

--- a/tools/readrpl/Makefile
+++ b/tools/readrpl/Makefile
@@ -26,4 +26,4 @@ install: all
 
 $(TARGET): $(CFILES)
 	@echo "[CXX] $(notdir $<)"
-	$(CXX) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS) $(CPPFORMATSRC)
+	@$(CXX) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS) $(CPPFORMATSRC)


### PR DESCRIPTION
In the Makefiles used in this project, there are several instances of the command:
```
ifeq ($(shell uname -o),Cygwin)
```
This command works flawlessly when running within Cygwin and on GNU/Linux. However, on my system (OS X Yosemite) this line results in the error:
```
uname: illegal option -- o
usage: uname [-amnprsv]
```

The aim of this PR is to fix that issue, but retain compatibility with Cygwin instances of make. What I have done involves searching for the string "CYGWIN" in the return of "uname". On OS X, the return value of just "uname" is "Darwin". On Linux, this is "GNU/Linux". On Windows (from research) this should be something along the lines of "CYGWINx.x ..." which should match and run the Windows specific build code.

Note that I haven't actually tested this on Windows (lack of Windows build setup) and if it doesn;t work on Windows, I apologise for wasting your time. 😛 

P.S. There is another remaining build issue that (for some unknown reason) causes the devkitPPC executables not being written to PATH by the Makefile, but this can be easily resolved by running `export PATH=$DEVKITPPC/bin:$PATH` before running `make`.