### PR TITLE
tempSize is based on all sections with a 0 address except RPL_CRCS and RPL_FILEINFO

### DIFF
--- a/tools/elf2rpl/main.cpp
+++ b/tools/elf2rpl/main.cpp
@@ -1007,7 +1007,7 @@ write(ElfFile &file, const std::string &filename)
          if(val > fileInfo.loadSize) {
             fileInfo.loadSize = val;
          }
-      } else if (section->header.type == elf::SHT_RELA) {
+      } else if (section->header.addr == 0 && section->header.type != elf::SHT_RPL_CRCS && section->header.type != elf::SHT_RPL_FILEINFO) {
          fileInfo.tempSize += (size + 128);
       }
    }


### PR DESCRIPTION
Fixes compiling with -g where .debug_* sections would be created but not accounted for in tempSize, while loader.elf would count them and fail on a bounds check.