### PR TITLE
Allow wut to build on OS X, fix helloworld example makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ifeq ($(shell uname -o),Cygwin)
+ifeq ($(shell uname -s),CYGWIN*)
 WUT_ROOT := $(shell cygpath -w ${CURDIR})
 else
 WUT_ROOT := $(CURDIR)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Doxygen output can be found at https://decaf-emu.github.io/wut
 
 ## Requirements
 - devkitPRO + devkitPPC
-- Only tested on Linux so far
+- Only tested on Linux and OS X so far
 
 ## Usage
 - git clone --recursive https://github.com/decaf-emu/wut.git

--- a/rpl/common/rules.mk
+++ b/rpl/common/rules.mk
@@ -1,6 +1,6 @@
 .SUFFIXES:
 
-ifeq ($(shell uname -o),Cygwin)
+ifeq ($(shell uname -s),CYGWIN*)
 CUR_DIR := $(shell cygpath -w ${CURDIR})
 else
 CUR_DIR := $(CURDIR)

--- a/rules/ppc.mk
+++ b/rules/ppc.mk
@@ -1,4 +1,4 @@
-ifeq ($(shell uname -o),Cygwin)
+ifeq ($(shell uname -s),CYGWIN*)
 WUT_ROOT := $(shell cygpath -w ${WUT_ROOT})
 else
 WUT_ROOT := $(WUT_ROOT)

--- a/samples/helloworld/Makefile
+++ b/samples/helloworld/Makefile
@@ -18,7 +18,7 @@ BUILD    := build
 SOURCE   := src
 INCLUDE  := include
 DATA     := data
-LIBS     := -lcoreinit -lproc_ui -lsysapp
+LIBS     := -lgcc -lcrt -lcoreinit -lproc_ui -lsysapp
 
 CFLAGS   += -O2 -Wall -std=c11
 CXXFLAGS += -O2 -Wall

--- a/samples/helloworld/Makefile
+++ b/samples/helloworld/Makefile
@@ -4,7 +4,7 @@ ifeq ($(strip $(WUT_ROOT)),)
 $(error "Please ensure WUT_ROOT is in your environment.")
 endif
 
-ifeq ($(shell uname -o),Cygwin)
+ifeq ($(shell uname -s),CYGWIN*)
 ROOT := $(shell cygpath -w ${CURDIR})
 WUT_ROOT := $(shell cygpath -w ${WUT_ROOT})
 else

--- a/samples/pong/Makefile
+++ b/samples/pong/Makefile
@@ -4,7 +4,7 @@ ifeq ($(strip $(WUT_ROOT)),)
 $(error "Please ensure WUT_ROOT is in your environment.")
 endif
 
-ifeq ($(shell uname -o),Cygwin)
+ifeq ($(shell uname -s),CYGWIN*)
 ROOT := $(shell cygpath -w ${CURDIR})
 WUT_ROOT := $(shell cygpath -w ${WUT_ROOT})
 else


### PR DESCRIPTION
`uname -o` is not available on OS X, which is why I replaced it with an equivalent command. 
I did not test building on Cygwin, so it would be great if someone did that before merging this.

The helloworld example also wasn't building because of missing libs in the Makefile.

It's not much, but a start, I guess.