### PR TITLE
Remove GX2 functions which don't exist in target system version

### DIFF
--- a/include/gx2/clear.h
+++ b/include/gx2/clear.h
@@ -23,23 +23,10 @@ GX2ClearColor(GX2ColorBuffer *colorBuffer,
               float alpha);
 
 void
-GX2ClearDepthStencil(GX2DepthBuffer *depthBuffer,
-                     GX2ClearFlags clearMode);
-
-void
 GX2ClearDepthStencilEx(GX2DepthBuffer *depthBuffer,
                        float depth,
                        uint8_t stencil,
                        GX2ClearFlags clearMode);
-
-void
-GX2ClearBuffers(GX2ColorBuffer *colorBuffer,
-                GX2DepthBuffer *depthBuffer,
-                float red,
-                float green,
-                float blue,
-                float alpha,
-                GX2ClearFlags clearMode);
 
 void
 GX2ClearBuffersEx(GX2ColorBuffer *colorBuffer,

--- a/rpl/libgx2/exports.h
+++ b/rpl/libgx2/exports.h
@@ -1,15 +1,12 @@
 // gx2/clear.h
 EXPORT(GX2ClearColor);
-EXPORT(GX2ClearDepthStencil);
 EXPORT(GX2ClearDepthStencilEx);
-EXPORT(GX2ClearBuffers);
 EXPORT(GX2ClearBuffersEx);
 EXPORT(GX2SetClearDepth);
 EXPORT(GX2SetClearStencil);
 EXPORT(GX2SetClearDepthStencil);
 
 // gx2/context.h
-EXPORT(GX2SetupContextState);
 EXPORT(GX2SetupContextStateEx);
 EXPORT(GX2GetContextStateDisplayList);
 EXPORT(GX2SetContextState);
@@ -29,7 +26,6 @@ EXPORT(GX2GetSystemDRCMode);
 
 // gx2/displaylist.h
 EXPORT(GX2BeginDisplayListEx);
-EXPORT(GX2BeginDisplayList);
 EXPORT(GX2EndDisplayList);
 EXPORT(GX2DirectCallDisplayList);
 EXPORT(GX2CallDisplayList);


### PR DESCRIPTION
Removed functions did not exist in gx2.rpl causing loader.elf to error.