### PR TITLE
Move rodata into text so that jump tables work properly without -fno-jump-tables

### DIFF
--- a/rules/ppc.mk
+++ b/rules/ppc.mk
@@ -1,5 +1,5 @@
 LIBPATHS  := -L$(WUT_ROOT)/lib
-CFLAGS    := -I$(WUT_ROOT)/include -fno-builtin -ffreestanding -fno-jump-tables  -std=c11
+CFLAGS    := -I$(WUT_ROOT)/include -fno-builtin -ffreestanding  -std=c11
 CXXFLAGS  := $(CFLAGS)
 LDFLAGS   := -nostdlib -nostartfiles
 

--- a/rules/rpl.ld
+++ b/rules/rpl.ld
@@ -32,6 +32,9 @@ SECTIONS {
       /* .text */
       *(.text)
       *(.text.*)
+      *(.rodata .rodata.*)
+      *(.gnu.linkonce.r.*)
+      *(.rodata1)
       *(.glue_7)
       *(.glue_7t)
       *(.stub)
@@ -51,12 +54,6 @@ SECTIONS {
 
    /* Standard data sections */
    . = ORIGIN(data);
-
-   .rodata ALIGN(256) : {
-      *(.rodata .rodata.*)
-      *(.gnu.linkonce.r.*)
-   } : hdr_sdata
-   .rodata1   : { *(.rodata1) }
 
    .data ALIGN(256) : {
       *(.data)

--- a/rules/rpl.mk
+++ b/rules/rpl.mk
@@ -1,5 +1,5 @@
 LIBPATHS  := -L$(WUT_ROOT)/lib -L$(DEVKITPPC)/lib
-CFLAGS    := -I$(WUT_ROOT)/include -fno-builtin -ffreestanding -fno-jump-tables
+CFLAGS    := -I$(WUT_ROOT)/include -fno-builtin -ffreestanding
 CXXFLAGS  := $(CFLAGS)
 LDFLAGS   := -nostartfiles -T $(WUT_ROOT)/rules/rpl.ld -pie -fPIE -z common-page-size=64 -z max-page-size=64 -lcrt \
 				-Wl,-wrap,malloc,-wrap,free,-wrap,memalign,-wrap,calloc,-wrap,realloc,-wrap,malloc_usable_size \

--- a/tools/elf2rpl/main.cpp
+++ b/tools/elf2rpl/main.cpp
@@ -441,6 +441,9 @@ read(ElfFile &file, const std::string &filename)
          } else if (addend >= DataAddress && addend < WiiuLoadAddress) {
             relocation->symbol = findSymbol(file, DataAddress);
             relocation->addend = addend - DataAddress;
+         } else if (addend >= CodeAddress && addend < DataAddress) {
+            relocation->symbol = findSymbol(file, CodeAddress);
+            relocation->addend = addend - CodeAddress;
          } else {
             // If we can't find a proper symbol, write the addend in and hope for the best
             auto ptr = getLoaderDataPtr<uint32_t>(inSections, rela.offset);


### PR DESCRIPTION
Lets us use DevKitPPC without having changes over there, plus better optimization. Only downside is that .rodata is just kinda part of .text, but to be honest that's not that big of a deal I don't think.