### PR TITLE
Added ICInvalidateRange to coreinit and modified Makefiles

### DIFF
--- a/include/coreinit/cache.h
+++ b/include/coreinit/cache.h
@@ -74,6 +74,10 @@ DCTouchRange(void *addr,
              uint32_t size);
 
 
+void
+ICInvalidateRange(void *addr,
+                  uint32_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rpl/libcoreinit/exports.h
+++ b/rpl/libcoreinit/exports.h
@@ -49,6 +49,7 @@ EXPORT(DCFlushRangeNoSync);
 EXPORT(DCStoreRangeNoSync);
 EXPORT(DCZeroRange);
 EXPORT(DCTouchRange);
+EXPORT(ICInvalidateRange);
 
 // coreinit/condition.h
 EXPORT(OSInitCond);

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -26,6 +26,7 @@ install: all
 
 else
 all:
+	@mkdir -p $(CURDIR)/bin
 	@for dir in $(TARGETS); do \
 		echo; \
 		echo Entering Directory $$dir; \
@@ -43,7 +44,7 @@ install: all
 	@mkdir -p $(INSTALLDIR)/bin
 	@for dir in $(TARGETS); do \
 		echo Installing $$dir; \
-		cp $$dir/$$dir $(INSTALLDIR)/bin; \
+		cp bin/$$dir $(INSTALLDIR)/bin; \
 	done
 endif
 

--- a/tools/elf2rpl/Makefile
+++ b/tools/elf2rpl/Makefile
@@ -15,6 +15,7 @@ all: $(TARGET)
 clean:
 	@echo "[RM] $(notdir $(TARGET))"
 	@rm -rf $(TARGET)
+	@rm -rf ../$(TARGET)
 
 install: all
 	@echo Installing $(TARGET)

--- a/tools/implcheck/Makefile
+++ b/tools/implcheck/Makefile
@@ -17,6 +17,7 @@ all: $(TARGET)
 clean:
 	@echo "[RM] $(notdir $(TARGET))"
 	@rm -rf $(TARGET)
+	@rm -rf ../$(TARGET)
 
 install: all
 	@echo Installing $(TARGET)
@@ -24,4 +25,4 @@ install: all
 
 $(TARGET): $(CFILES)
 	@echo "[CXX] $(notdir $<)"
-	$(CXX) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS) $(CPPFORMATSRC)
+	@$(CXX) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS) $(CPPFORMATSRC)

--- a/tools/implcheck/main.cpp
+++ b/tools/implcheck/main.cpp
@@ -136,7 +136,7 @@ readRPL(RplInfo &info, std::ifstream &fh)
    }
 
    // Find strtab
-   auto shStrTab = reinterpret_cast<const char *>(sections[header.shstrndx].data.data());
+   //auto shStrTab = reinterpret_cast<const char *>(sections[header.shstrndx].data.data());
 
    // Print section data
    for (auto i = 0u; i < sections.size(); ++i) {
@@ -336,4 +336,3 @@ int main(int argc, char **argv)
 
    return result;
 }
-

--- a/tools/readrpl/Makefile
+++ b/tools/readrpl/Makefile
@@ -17,6 +17,7 @@ all: $(TARGET)
 clean:
 	@echo "[RM] $(notdir $(TARGET))"
 	@rm -rf $(TARGET)
+	@rm -rf ../$(TARGET)
 
 install: all
 	@echo Installing $(TARGET)
@@ -24,4 +25,4 @@ install: all
 
 $(TARGET): $(CFILES)
 	@echo "[CXX] $(notdir $<)"
-	$(CXX) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS) $(CPPFORMATSRC)
+	@$(CXX) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS) $(CPPFORMATSRC)


### PR DESCRIPTION
While working on my current project (AutoBoot) I needed access to the function ICInvalidateRange. I added it to coreinit/cache.h, as I believe that would be where it belongs. This information is based on data already reversed by developers and is public on wiiubrew.org.

I also modified the makefiles to handle the creation of bin folders automatically, which didn't already happen. The lack of bin folders caused Xcode's clang compiler to fail building, so having the script automatically generate bin folders helps make the process a little more automated.