### PR TITLE
Extended FSStat struct based on HBL

### DIFF
--- a/include/coreinit/filesystem.h
+++ b/include/coreinit/filesystem.h
@@ -153,14 +153,19 @@ struct FSCmdBlock
 };
 CHECK_SIZE(FSCmdBlock, 0xA80);
 
-struct FSStat
+struct __attribute__((__packed__)) FSStat
 {
    FSStatFlags flags;
    FSMode mode;
    uint32_t owner;
    uint32_t group;
    uint32_t size;
-   UNKNOWN(0x50);
+   uint32_t alloc;
+   uint64_t quota;
+   uint32_t ent;
+   uint64_t created;
+   uint64_t modified;
+   UNKNOWN(0x30);
 };
 CHECK_OFFSET(FSStat, 0x00, flags);
 CHECK_OFFSET(FSStat, 0x10, size);


### PR DESCRIPTION
My current project involved porting a program (Space Game) from @dimok789's ELF format into an RPX format.

In doing so, I noticed that there were some differences in the filesystem code used in dimok's library and WUT. This meant that I was forced to either edit WUT's library, or define the struct myself and call it FSStat_alt (I really did try that).

This PR "bridges the gap" and adds dimok's findings for the FSStat struct into WUT, in a way that allows Space Game to compile without any compiler warnings about FSStat_alt being used in place of FSStat.