### PR TITLE
Pong: Fix build issues with CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ cd wut
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=install ../
 make
+make install
 export WUT_ROOT=$PWD/install
 ```
 

--- a/samples/pong/CMakeLists.txt
+++ b/samples/pong/CMakeLists.txt
@@ -3,8 +3,8 @@ project(pong)
 
 include($ENV{WUT_ROOT}/cmake/wut-toolchain.cmake)
 
-file(GLOB_RECURSE SOURCE_FILES *.c)
-file(GLOB_RECURSE HEADER_FILES *.h)
+file(GLOB_RECURSE SOURCE_FILES src/*.c)
+file(GLOB_RECURSE HEADER_FILES src/*.h)
 
 add_rpx(pong ${SOURCE_FILES} ${HEADER_FILES})
 target_link_libraries(pong


### PR DESCRIPTION
The `CMakeLists.txt` file in the `samples/pong` directory specifies that all C source and header files in the `samples/pong` directory are to be included in the build. Because we do not specify that only the `src` folder should be used in the build, CMake also builds its compiler test programs and tries to link them with Pong. This results in `main()` being defined twice, which causes a linker error. This commit fixes that by filtering the build to only source files in the `src` directory.

You also missed a very important instruction in the README that had me stumped for a while (I don't build UNIX software often, hence why it took me a while to figure out). 😆