### PR TITLE
Various small fixes

### DIFF
--- a/samples/gx2/triangle/CMakeLists.txt
+++ b/samples/gx2/triangle/CMakeLists.txt
@@ -11,4 +11,6 @@ target_link_libraries(triangle
     defaultheap
     gx2
     gfd
-    proc_ui)
+    nsysnet
+    proc_ui
+    sysapp)

--- a/samples/gx2/triangle/src/main.c
+++ b/samples/gx2/triangle/src/main.c
@@ -113,7 +113,7 @@ exit:
    WHBLogPrintf("Exiting...");
    GX2RDestroyBufferEx(&positionBuffer, 0);
    GX2RDestroyBufferEx(&colourBuffer, 0);
-   //WHBUnmountSdCard(); !! freezes on unmount for unkown reason !!
+   WHBUnmountSdCard();
    WHBGfxShutdown();
    WHBProcShutdown();
    return result;

--- a/src/crt/newlib.c
+++ b/src/crt/newlib.c
@@ -70,7 +70,7 @@ static int __libwut_lock_close(int *lock)
 
 static int __libwut_lock_acquire(int *lock)
 {
-   OSMutex *mutex = (OSMutex *)lock;
+   OSMutex *mutex = (OSMutex *)*lock;
    if (!lock || *lock == 0) {
       return -1;
    }
@@ -81,7 +81,7 @@ static int __libwut_lock_acquire(int *lock)
 
 static int __libwut_lock_release(int *lock)
 {
-   OSMutex *mutex = (OSMutex *)lock;
+   OSMutex *mutex = (OSMutex *)*lock;
    if (!lock || *lock == 0) {
       return -1;
    }

--- a/src/libwhb/include/whb/log_cafe.h
+++ b/src/libwhb/include/whb/log_cafe.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <wut.h>
+
+/**
+ * \defgroup whb_log_cafe Cafe OS System Log Output
+ * \ingroup whb
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+BOOL
+WHBLogCafeInit();
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/src/libwhb/src/log_cafe.c
+++ b/src/libwhb/src/log_cafe.c
@@ -1,0 +1,15 @@
+#include <coreinit/debug.h>
+#include <whb/log.h>
+
+static void
+cafeLogHandler(const char * msg)
+{
+   OSReport("%s\n", msg);
+}
+
+BOOL
+WHBLogCafeInit()
+{
+   WHBAddLogHandler(cafeLogHandler);
+   return TRUE;
+}

--- a/src/libwhb/src/sdcard.c
+++ b/src/libwhb/src/sdcard.c
@@ -67,6 +67,8 @@ WHBUnmountSdCard()
       return TRUE;
    }
 
+   FSInitCmdBlock(&cmd);
+
    result = FSUnmount(&sClient, &cmd, sMountPath, -1);
    if (result < 0) {
       WHBLogPrintf("%s: FSUnmount error %d", __FUNCTION__, result);


### PR DESCRIPTION
This PR addresses a few issues that have been faced by both myself and issues that have been within the repo before.

## CRT: Correcting mutex issues in libc functions
Last month, you pushed changes to attempt fixing this issue. But it wasn't until I tried re-building from `master` yesterday that I found that your changes did not fix the issue. This PR includes (what I think is, at least) the proper fix for this issue. (see #55 for more details)

## libWHB: Fix WHBUnmountSdCard
The GX2 Triangle demo had the line `WHBUnmountSdCard();` commented out because it froze the console when run. This is because the `FsCmdBlock` being used within that function is never initialised. As such, it will likely contain invalid data. I rectify this by calling `FSInitCmdBlock` before calling `FSUnmount`.

(I have also updated the triangle demo's CMake script to include new libraries required by libwhb, note that it still does not display anything on retail hardware, I was unable to find the solution for this).

## libWHB: Add a simplistic Cafe OS Logger
This new logger simply calls `OSReport`, storing anything passed to `WHBLogPrint` within the Cafe OS system log. This is especially useful for debugging purposes, as if a program crashes, the syslog will show the last action the program performed before outputting crash dump information.