### PR TITLE
libWHB exception handler now works

### DIFF
--- a/src/libwhb/src/crash.c
+++ b/src/libwhb/src/crash.c
@@ -40,7 +40,7 @@ sRegistersLength = 0;
 static uint8_t
 sCrashThreadStack[THREAD_STACK_SIZE];
 
-static OSThread
+static OSThread __attribute__((aligned(8)))
 sCrashThread;
 
 static int
@@ -96,7 +96,7 @@ getStackTrace(OSContext *context)
    for (i = 0; i < 16; ++i) {
       uint32_t addr;
 
-      if (!stackPtr || (uintptr_t)stackPtr == 0xFFFFFFFF) {
+      if (!stackPtr || (uintptr_t)stackPtr == 0x1 || (uintptr_t)stackPtr == 0xFFFFFFFF) {
          break;
       }
 


### PR DESCRIPTION
> whb: Add crash handler based off the one in coreinit.
> Although I'm not convinced it's actually working... yet.

This PR makes two small patches to the exception handling code present in `libwhb` which allow the exception handler to actually work, at least for me.

During handling of stack dumps, a loop is used to traverse the stack. Within the loop, it is checked whether or not the variable supposed to hold the stack pointer is either `null` or `0xFFFFFFFF`. However, at least for me, the entry at the bottom of the stack always has a back-chain value of `0x1` which is not handled by this loop. As such, the handler attempts to read data from `0x1`, causing another exception. The fix for this was to consider `0x1` to be the end of the stack, in addition to `null` and `0xFFFFFFFF`.

After changing this, I found that the next freeze was being caused by your call to `OSCreateThread`. After doing some hunting, there was a message in my syslog along the lines of, "thread context must be aligned to at least 8 bytes." (Unfortunately I lost the actual string that was printed). And so I aligned the `OSThread` structure to 8 bytes to fix this issue.

So the exception handler now works. At least partially.

I experimented with triggering exceptions using the following code:

```
WHBLogUdpInit();
WHBInitCrashHandler();

// I think this is an ISI exception
void(*myFakeFunction)() = 0;
myFakeFunction();

// I think this is a DSI Exception
int *myFakeInt = 0;
*myFakeInt = 0;
```

In the case of ISI exceptions, the exception handler only prints out the stack dump. And during DSI exceptions, the handler only prints out the disassembly and stack dump. I cannot seem to be able to trigger the register dumps to be printed out. And I have no idea what's causing this. It could simply be fickle networking issues, but this seems to happen every time I try.

In addition to this, I have a question regarding code in the exception handler that I'm not entirely sure about. On line 222 you wrote:
```
OSSuspendThread((OSThread *)context);
```
Shouldn't this be `OSJoinThread` because we want to wait for the thread to finish naturally? Or is this actually correct?

That's all. Thanks!