### PR TITLE
wut-toolchain: Properly escape include/lib paths

### DIFF
--- a/cmake/wut-toolchain.cmake
+++ b/cmake/wut-toolchain.cmake
@@ -45,27 +45,27 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
 set(DEVKIT_COMPILE_FLAGS "-mcpu=750 -meabi -mhard-float -mno-sdata")
-set(DEVKIT_LINKER_FLAGS "-nostartfiles -L${DEVKITPPC}/lib")
+set(DEVKIT_LINKER_FLAGS "-nostartfiles \"-L${DEVKITPPC}/lib\"")
 
 set(RPX_COMPILE_FLAGS "${DEVKIT_COMPILE_FLAGS}")
 
 set(RPX_LINKER_FLAGS "\
     ${DEVKIT_LINKER_FLAGS} \
-    -pie -fPIE -z common-page-size=64 -z max-page-size=64 -T ${WUT_ROOT}/rules/rpl.ld\
-    -L${WUT_ROOT}/lib -Wl,-wrap,__eabi")
+    -pie -fPIE -z common-page-size=64 -z max-page-size=64 -T \"${WUT_ROOT}/rules/rpl.ld\"\
+    \"-L${WUT_ROOT}/lib\" -Wl,-wrap,__eabi")
 
 set(ELF_TO_RPL ${WUT_ROOT}/bin/elf2rpl${CMAKE_EXECUTABLE_SUFFIX})
 
 if(CMAKE_INCLUDE_PATH)
 set(RPX_COMPILE_FLAGS "\
     ${RPX_COMPILE_FLAGS} \
-    -I${CMAKE_INCLUDE_PATH}")
+    \"-I${CMAKE_INCLUDE_PATH}\"")
 endif()
 
 if(CMAKE_LIBRARY_PATH)
 set(RPX_LINKER_FLAGS "\
     ${RPX_LINKER_FLAGS} \
-    -L${CMAKE_LIBRARY_PATH}")
+    \"-L${CMAKE_LIBRARY_PATH}\"")
 endif()
 
 macro(add_rpx target)


### PR DESCRIPTION
This allows WUT to successfully operate within a path that contains spaces.

I discovered this when I was attempting to build my current project on Windows, in which my home directory contains spaces. (that was a good idea, eh?)