### PR TITLE
cmake: Use include_directories instead of -I cflags

### DIFF
--- a/share/wut.toolchain.cmake
+++ b/share/wut.toolchain.cmake
@@ -23,11 +23,14 @@ set(CMAKE_LINKER           "${DEVKITPPC}/bin/powerpc-eabi-ld${CMAKE_EXECUTABLE_S
 set(CMAKE_AR               "${DEVKITPPC}/bin/powerpc-eabi-ar${CMAKE_EXECUTABLE_SUFFIX}"    CACHE PATH "")
 set(CMAKE_STRIP            "${DEVKITPPC}/bin/powerpc-eabi-strip${CMAKE_EXECUTABLE_SUFFIX}" CACHE PATH "")
 
-set(WUT_C_FLAGS            "-mcpu=750 -meabi -mhard-float -Wl,-q \"-I${WUT_ROOT}/include\" -D__WIIU__ -D__WUT__")
+set(WUT_C_FLAGS            "-mcpu=750 -meabi -mhard-float -Wl,-q -D__WIIU__ -D__WUT__")
 set(CMAKE_C_FLAGS          "${WUT_C_FLAGS}" CACHE STRING "")
 set(CMAKE_CXX_FLAGS        "${WUT_C_FLAGS}" CACHE STRING "")
 set(CMAKE_ASM_FLAGS        "${WUT_C_FLAGS}" CACHE STRING "")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,nocopyreloc -T \"${WUT_ROOT}/share/wut.ld\" \"-L${WUT_ROOT}/lib\"" CACHE STRING "")
+
+# Include paths for wut
+include_directories(BEFORE SYSTEM "${WUT_ROOT}/include")
 
 # Setup root to exclude host system headers + libraries
 set(CMAKE_FIND_ROOT_PATH "${DEVKITPPC}" "${WUT_ROOT}/bin" "${CMAKE_INSTALL_PREFIX}" "${CMAKE_INSTALL_PREFIX}/share")


### PR DESCRIPTION
Heyo! Just a small thing - using include_directories instead of `-I`.
This helps some cmake analysers and the like to better get an idea of how wut works, while having the same effect in terms of actual compiling. In my case, it meant the IDEs I was experimenting with would find wut's headers without extra help!
If there's some reason this wasn't done initially, I'd be glad to hear it. Not too attached to this change, though it would be nice ;D
Thanks again!
-Ash