### PR TITLE
h264/decode: Make `H264DECSetParam_USER_MEMORY` take `void**`

### DIFF
--- a/include/h264/decode.h
+++ b/include/h264/decode.h
@@ -80,7 +80,7 @@ H264DECSetParam_OUTPUT_PER_FRAME(void *memory,
  */
 H264Error
 H264DECSetParam_USER_MEMORY(void *memory,
-                            void *value);
+                            void **value);
 
 
 /**


### PR DESCRIPTION
`userMemory` value given in decode callback is the data obtained by de-referencing `value`