### PR TITLE
Update Terminology in Swkbd and Slightly Update Samples

### DIFF
--- a/include/nn/swkbd/swkbd_cpp.h
+++ b/include/nn/swkbd/swkbd_cpp.h
@@ -98,10 +98,10 @@ enum class State
 
 enum class InputFormType
 {
-   //! Input form seen when adding an NNID on Friends List or creating a folder on the System Menu. (Individual square design with up to 40 characters)
-   InputForm0 = 0,
-   //! The default input layout that is usually used (Page design)
-   Default    = 1,
+   //! Spaced boxes design with up to 40 characters
+   Boxes = 0,
+   //! The page design
+   Page    = 1,
 };
 
 enum class KeyboardLayout
@@ -247,7 +247,7 @@ WUT_CHECK_SIZE(KeyboardArg, 0xC0);
 struct InputFormArg
 {
    //! The type of input form
-   InputFormType type                   = InputFormType::Default;
+   InputFormType type                   = InputFormType::Page;
    int32_t unk_0x04                     = -1;
    //! Initial string to open the keyboard with
    const char16_t *initialText          = nullptr;
@@ -258,8 +258,8 @@ struct InputFormArg
    //! Which password inputting preset to use
    nn::swkbd::PasswordMode passwordMode = nn::swkbd::PasswordMode::Clear;
    uint32_t unk_0x18                    = 0;
-   //! Whether or not to draw a cursor. Exclusive to the inputform0 input form type.
-   bool drawInput0Cursor                = false;
+   //! Whether or not to draw a cursor. Exclusive to the boxes input form type.
+   bool drawCursorForBoxes              = true;
    //! Whether or not to highlight the initial string. Exclusive to the Default input form type.
    bool higlightInitialText             = false;
    //! Whether or not to show a copy and a paste button.
@@ -273,7 +273,7 @@ WUT_CHECK_OFFSET(InputFormArg, 0x0C, hintText);
 WUT_CHECK_OFFSET(InputFormArg, 0x10, maxTextLength);
 WUT_CHECK_OFFSET(InputFormArg, 0x14, passwordMode);
 WUT_CHECK_OFFSET(InputFormArg, 0x18, unk_0x18);
-WUT_CHECK_OFFSET(InputFormArg, 0x1C, drawInput0Cursor);
+WUT_CHECK_OFFSET(InputFormArg, 0x1C, drawCursorForBoxes);
 WUT_CHECK_OFFSET(InputFormArg, 0x1D, higlightInitialText);
 WUT_CHECK_OFFSET(InputFormArg, 0x1E, showCopyPasteButtons);
 WUT_CHECK_SIZE(InputFormArg, 0x20);

--- a/include/nn/swkbd/swkbd_cpp.h
+++ b/include/nn/swkbd/swkbd_cpp.h
@@ -101,7 +101,7 @@ enum class InputFormType
    //! Spaced boxes design with up to 40 characters
    Boxes = 0,
    //! The page design
-   Page    = 1,
+   Page  = 1,
 };
 
 enum class KeyboardLayout

--- a/samples/cmake/erreula/main.cpp
+++ b/samples/cmake/erreula/main.cpp
@@ -36,7 +36,7 @@ main(int argc, char **argv)
       return -1;
    }
 
-   // Play the sound effect that plays when erreula appears on screen
+   // Play a sound effect that will play when erreula appears on screen
    nn::erreula::PlayAppearSE(true);
 
    // Show the error viewer

--- a/samples/cmake/erreula/main.cpp
+++ b/samples/cmake/erreula/main.cpp
@@ -51,8 +51,8 @@ main(int argc, char **argv)
    nn::erreula::AppearErrorViewer(appearArg);
 
    // Get WHBGfx's colour buffers for proper erreula rendering
-   GX2ColorBuffer *cbTV = WHBGfxGetTVColourBuffer();
-   GX2ColorBuffer *cbDRC = WHBGfxGetDRCColourBuffer();     
+   GX2ColorBuffer *cbTV  = WHBGfxGetTVColourBuffer();
+   GX2ColorBuffer *cbDRC = WHBGfxGetDRCColourBuffer();
 
    WHBLogPrintf("Begin rendering...");
    while (WHBProcIsRunning()) {
@@ -84,7 +84,7 @@ main(int argc, char **argv)
       cbTV->surface.format = GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8;
       GX2InitColorBufferRegs(cbTV);
       GX2SetColorBuffer(cbTV, GX2_RENDER_TARGET_0);
-      
+
       nn::erreula::DrawTV();
 
       // Set our colour buffer's surface format back to what it was before.

--- a/samples/cmake/erreula/main.cpp
+++ b/samples/cmake/erreula/main.cpp
@@ -1,6 +1,5 @@
 #include <coreinit/filesystem.h>
 #include <coreinit/memdefaultheap.h>
-#include <gx2/surface.h>
 #include <nn/erreula.h>
 #include <sndcore2/core.h>
 #include <sysapp/launch.h>
@@ -50,10 +49,6 @@ main(int argc, char **argv)
    appearArg.errorArg.errorTitle     = u"Title";
    nn::erreula::AppearErrorViewer(appearArg);
 
-   // Get WHBGfx's colour buffers for proper erreula rendering
-   GX2ColorBuffer *cbTV  = WHBGfxGetTVColourBuffer();
-   GX2ColorBuffer *cbDRC = WHBGfxGetDRCColourBuffer();
-
    WHBLogPrintf("Begin rendering...");
    while (WHBProcIsRunning()) {
       // Read vpad for erreula::Calc
@@ -72,6 +67,7 @@ main(int argc, char **argv)
 
       if (nn::erreula::IsDecideSelectButtonError()) {
          nn::erreula::DisappearErrorViewer();
+         // Cause ProcUI to exit.
          SYSLaunchMenu();
       }
 
@@ -79,32 +75,12 @@ main(int argc, char **argv)
 
       WHBGfxBeginRenderTV();
       WHBGfxClearColor(0.0f, 0.0f, 1.0f, 1.0f);
-      // Set our colour buffer's surface format to SRGB for correct rendering of erreula
-      GX2SurfaceFormat fTV = cbTV->surface.format;
-      cbTV->surface.format = GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8;
-      GX2InitColorBufferRegs(cbTV);
-      GX2SetColorBuffer(cbTV, GX2_RENDER_TARGET_0);
-
       nn::erreula::DrawTV();
-
-      // Set our colour buffer's surface format back to what it was before.
-      cbTV->surface.format = fTV;
-      GX2InitColorBufferRegs(cbTV);
-      GX2SetColorBuffer(cbTV, GX2_RENDER_TARGET_0);
       WHBGfxFinishRenderTV();
 
       WHBGfxBeginRenderDRC();
       WHBGfxClearColor(1.0f, 0.0f, 1.0f, 1.0f);
-      GX2SurfaceFormat fDRC = cbDRC->surface.format;
-      cbDRC->surface.format = GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8;
-      GX2InitColorBufferRegs(cbDRC);
-      GX2SetColorBuffer(cbDRC, GX2_RENDER_TARGET_0);
-
       nn::erreula::DrawDRC();
-
-      cbDRC->surface.format = fDRC;
-      GX2InitColorBufferRegs(cbDRC);
-      GX2SetColorBuffer(cbDRC, GX2_RENDER_TARGET_0);
       WHBGfxFinishRenderDRC();
 
       WHBGfxFinishRender();

--- a/samples/cmake/swkbd/main.cpp
+++ b/samples/cmake/swkbd/main.cpp
@@ -1,5 +1,6 @@
 #include <coreinit/filesystem.h>
 #include <coreinit/memdefaultheap.h>
+#include <gx2/surface.h>
 #include <nn/swkbd.h>
 #include <sndcore2/core.h>
 #include <sysapp/launch.h>
@@ -17,7 +18,6 @@ main(int argc, char **argv)
    WHBProcInit();
    WHBGfxInit();
    FSInit();
-   VPADInit();
    AXInit();
 
    // Create FSClient for swkbd
@@ -35,9 +35,6 @@ main(int argc, char **argv)
       return -1;
    }
 
-   // Enable sound
-   nn::swkbd::MuteAllSound(false);
-
    // Show the keyboard
    nn::swkbd::AppearArg appearArg;
    appearArg.keyboardArg.configArg.languageType = nn::swkbd::LanguageType::English;
@@ -47,6 +44,10 @@ main(int argc, char **argv)
       WHBProcShutdown();
       return -1;
    }
+
+   // Get WHBGfx's colour buffers for proper swkbd rendering
+   GX2ColorBuffer *cbTV = WHBGfxGetTVColourBuffer();
+   GX2ColorBuffer *cbDRC = WHBGfxGetDRCColourBuffer();   
 
    WHBLogPrintf("Begin rendering...");
    while (WHBProcIsRunning()) {
@@ -82,12 +83,32 @@ main(int argc, char **argv)
 
       WHBGfxBeginRenderTV();
       WHBGfxClearColor(0.0f, 0.0f, 1.0f, 1.0f);
+      // Set our colour buffer's surface format to SRGB for correct rendering of swkbd
+      GX2SurfaceFormat fTV = cbTV->surface.format;
+      cbTV->surface.format = GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8;
+      GX2InitColorBufferRegs(cbTV);
+      GX2SetColorBuffer(cbTV, GX2_RENDER_TARGET_0);
+      
       nn::swkbd::DrawTV();
+
+      // Set our colour buffer's surface format back to what it was before.
+      cbTV->surface.format = fTV;
+      GX2InitColorBufferRegs(cbTV);
+      GX2SetColorBuffer(cbTV, GX2_RENDER_TARGET_0);
       WHBGfxFinishRenderTV();
 
       WHBGfxBeginRenderDRC();
       WHBGfxClearColor(1.0f, 0.0f, 1.0f, 1.0f);
+      GX2SurfaceFormat fDRC = cbDRC->surface.format;
+      cbDRC->surface.format = GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8;
+      GX2InitColorBufferRegs(cbDRC);
+      GX2SetColorBuffer(cbDRC, GX2_RENDER_TARGET_0);
+
       nn::swkbd::DrawDRC();
+
+      cbDRC->surface.format = fDRC;
+      GX2InitColorBufferRegs(cbDRC);
+      GX2SetColorBuffer(cbDRC, GX2_RENDER_TARGET_0);
       WHBGfxFinishRenderDRC();
 
       WHBGfxFinishRender();

--- a/samples/cmake/swkbd/main.cpp
+++ b/samples/cmake/swkbd/main.cpp
@@ -46,8 +46,8 @@ main(int argc, char **argv)
    }
 
    // Get WHBGfx's colour buffers for proper swkbd rendering
-   GX2ColorBuffer *cbTV = WHBGfxGetTVColourBuffer();
-   GX2ColorBuffer *cbDRC = WHBGfxGetDRCColourBuffer();   
+   GX2ColorBuffer *cbTV  = WHBGfxGetTVColourBuffer();
+   GX2ColorBuffer *cbDRC = WHBGfxGetDRCColourBuffer();
 
    WHBLogPrintf("Begin rendering...");
    while (WHBProcIsRunning()) {
@@ -88,7 +88,7 @@ main(int argc, char **argv)
       cbTV->surface.format = GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8;
       GX2InitColorBufferRegs(cbTV);
       GX2SetColorBuffer(cbTV, GX2_RENDER_TARGET_0);
-      
+
       nn::swkbd::DrawTV();
 
       // Set our colour buffer's surface format back to what it was before.

--- a/samples/cmake/swkbd/main.cpp
+++ b/samples/cmake/swkbd/main.cpp
@@ -45,10 +45,6 @@ main(int argc, char **argv)
       return -1;
    }
 
-   // Get WHBGfx's colour buffers for proper swkbd rendering
-   GX2ColorBuffer *cbTV  = WHBGfxGetTVColourBuffer();
-   GX2ColorBuffer *cbDRC = WHBGfxGetDRCColourBuffer();
-
    WHBLogPrintf("Begin rendering...");
    while (WHBProcIsRunning()) {
       // Read vpad for swkbd::Calc
@@ -83,32 +79,12 @@ main(int argc, char **argv)
 
       WHBGfxBeginRenderTV();
       WHBGfxClearColor(0.0f, 0.0f, 1.0f, 1.0f);
-      // Set our colour buffer's surface format to SRGB for correct rendering of swkbd
-      GX2SurfaceFormat fTV = cbTV->surface.format;
-      cbTV->surface.format = GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8;
-      GX2InitColorBufferRegs(cbTV);
-      GX2SetColorBuffer(cbTV, GX2_RENDER_TARGET_0);
-
       nn::swkbd::DrawTV();
-
-      // Set our colour buffer's surface format back to what it was before.
-      cbTV->surface.format = fTV;
-      GX2InitColorBufferRegs(cbTV);
-      GX2SetColorBuffer(cbTV, GX2_RENDER_TARGET_0);
       WHBGfxFinishRenderTV();
 
       WHBGfxBeginRenderDRC();
       WHBGfxClearColor(1.0f, 0.0f, 1.0f, 1.0f);
-      GX2SurfaceFormat fDRC = cbDRC->surface.format;
-      cbDRC->surface.format = GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8;
-      GX2InitColorBufferRegs(cbDRC);
-      GX2SetColorBuffer(cbDRC, GX2_RENDER_TARGET_0);
-
       nn::swkbd::DrawDRC();
-
-      cbDRC->surface.format = fDRC;
-      GX2InitColorBufferRegs(cbDRC);
-      GX2SetColorBuffer(cbDRC, GX2_RENDER_TARGET_0);
       WHBGfxFinishRenderDRC();
 
       WHBGfxFinishRender();


### PR DESCRIPTION
- Clarifies the ``nn::swkbd::InputFormType`` enumerator's members' names.
- Sets the cursor that can appear in the Boxes input form type to appear by default.
- Updates the swkbd and erreula samples to correctly render swkbd and erreula, as well cleaning up their code. *There was a call to `VPADInit`, for example which is a deprecated function.*