### PR TITLE
coreinit/filesystem: Label HFIO/PCFS mount source type

### DIFF
--- a/include/coreinit/filesystem.h
+++ b/include/coreinit/filesystem.h
@@ -193,7 +193,8 @@ typedef enum FSMediaState
 typedef enum FSMountSourceType
 {
    FS_MOUNT_SOURCE_SD   = 0,
-   FS_MOUNT_SOURCE_PCFS = 1,
+   //! Devkit only API currently. Uses the PCFS channel to perform I/O operations on the attached host machine.
+   FS_MOUNT_SOURCE_HFIO = 1,
 } FSMountSourceType;
 
 typedef enum FSOpenFileFlags


### PR DESCRIPTION
now that we've got an open-source way of booting a cat-dev using PCFS without the official SDK (<https://codeberg.org/rem-verse/sprig>, this also contains the source code i used to generate the image below at: <https://codeberg.org/rem-verse/sprig/src/commit/760514b5e762de0edbf466a0d3f3ce06ee7a5513/console/apps/hfiod>), we can confirm that this second mount source is indeed PCFS. Testing this code on a real cat-dev, allows me to list files on the attached host system.

<img width="545" height="150" alt="A file listing of the host filesystem that is connected to a cat-dev over PCFS." src="https://github.com/user-attachments/assets/2c17cf20-5048-4ec9-9b3b-8d00601c9862" />

---

I chose to label this "PCFS" even though based on the mount name says "HFIO" (I assume for "host file i/o"), while these deviates from the mount name, PCFS is much more clear as PCFS is not the _only_ way a cat-dev can do i/o with an attached 'host' system (none of the others are supported by this mount type), not to mention PCFS has certain limitations (e.g. can only do 'simple' filesystem permissions, supports the max length of PCFS, etc.).