### PR TITLE
Include `wut.h` in `h264/stream.h`

### DIFF
--- a/include/h264/stream.h
+++ b/include/h264/stream.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <wut.h>
+
 /**
  * \defgroup h264_stream H264 Stream
  * \ingroup h264


### PR DESCRIPTION
Not having `wut.h` included when using this header results in redefinition errors because of `WUT_PACKED`