### PR TITLE
add OSGetConsoleType, and MCP_GetSystemMode

### DIFF
--- a/include/coreinit/core.h
+++ b/include/coreinit/core.h
@@ -14,6 +14,9 @@ extern "C" {
 #endif
 
 
+#define OS_CONSOLE_TYPE_MASK 0xF0000000
+
+
 /**
  * Gets the number of cores in the system. On a retail Wii U, this is always 3.
  *
@@ -56,6 +59,22 @@ OSGetMainCoreId();
  */
 BOOL
 OSIsMainCore();
+
+
+/**
+ * Get the type of console this code is actively running on.
+ *
+ * Most of the field is relatively unknown but you can use
+ * \ref OS_CONSOLE_TYPE_MASK
+ * which returns whether the unit is a Retail/CAT-R unit with 0,
+ * a CAT-DEV or other CAFE development board with 1, and an orchestrax
+ * unit with 2.
+ *
+ * \returns
+ * A number representing the specific console types.
+ */
+uint32_t
+OSGetConsoleType();
 
 
 #ifdef __cplusplus

--- a/include/coreinit/core.h
+++ b/include/coreinit/core.h
@@ -14,6 +14,12 @@ extern "C" {
 #endif
 
 
+/**
+ * Can be used to mask the return value of
+ * \ref OSGetConsoleType
+ * for determining the "group" of console. See the function for more
+ * information around the values the mask gives.
+ */
 #define OS_CONSOLE_TYPE_MASK 0xF0000000
 
 
@@ -66,9 +72,9 @@ OSIsMainCore();
  *
  * Most of the field is relatively unknown but you can use
  * \ref OS_CONSOLE_TYPE_MASK
- * which returns whether the unit is a Retail/CAT-R unit with 0,
- * a CAT-DEV or other CAFE development board with 1, and an orchestrax
- * unit with 2.
+ * which returns whether the unit is a Retail/CAT-R unit with `0x00000000`,
+ * a CAT-DEV or other CAFE development board with `0x10000000`, and an
+ * orchestrax unit with `0x20000000`.
  *
  * \returns
  * A number representing the specific console types.

--- a/include/coreinit/mcp.h
+++ b/include/coreinit/mcp.h
@@ -102,6 +102,16 @@ typedef enum MCPCompatAVFile
    MCP_COMPAT_AV_FILE_DEINT = 0x01,
 } MCPCompatAVFile;
 
+typedef enum MCPSystemMode
+{
+   //! This unit is in 'retail'/'production' mode.
+   MCP_PRODUCTION  = 0x00,
+   //! This unit is in 'development' mode (default for CAT-DEV).
+   MCP_DEVELOPMENT = 0x01,
+   //! This unit is in 'test' mode.
+   MCP_TEST        = 0x02,
+} MCPSystemMode;
+
 struct WUT_PACKED MCPDevice
 {
    char type[8];
@@ -242,6 +252,10 @@ MCP_GetOwnTitleInfo(int32_t handle,
                     MCPTitleListType *titleInfo);
 
 MCPError
+MCP_GetSystemMode(int32_t handle,
+                  MCPSystemMode *mode);
+
+MCPError
 MCP_GetSysProdSettings(int32_t handle,
                        MCPSysProdSettings *settings);
 
@@ -363,7 +377,7 @@ MCP_CompatLoadAVFile(int32_t handle,
 /**
  * Saves the current Cafe log to the SLC logs directory.
  * Internally calls IOS_Ioctl() with request \c 0xCD .
- * 
+ *
  * \return
  * \c 0 on success.
  */


### PR DESCRIPTION
this adds in two functions that were an exported symbol in the system libraries, but not included in any headers. these are useful for doing two things:

- determine what kind of console you're running on (for users who want to know if they're running a CAT-DEV, CAT-R, Kiosk Unit, Retail Wii-U's, etc.)
- determine if the wii-u is currently running in production/development mode. this shouldn't be too useful for many users, as not too much changes besides certain extra libraries/etc. are loaded in memory. however, users may want to lock things behind development mode as dev mode can only be normally enabled when there's extra memory.