### PR TITLE
gx2/context: `GX2SetupContextStateEx` takes a flags bitfield

### DIFF
--- a/include/gx2/context.h
+++ b/include/gx2/context.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <wut.h>
+#include "gx2/enum.h"
 
 /**
  * \defgroup gx2_context Context State
@@ -49,7 +50,7 @@ WUT_CHECK_SIZE(GX2ContextState, 0xa100);
 
 void
 GX2SetupContextStateEx(GX2ContextState *state,
-                       BOOL unk1);
+                       GX2ContextStateFlags flags);
 
 void
 GX2GetContextStateDisplayList(const GX2ContextState *state,

--- a/include/gx2/enum.h
+++ b/include/gx2/enum.h
@@ -167,6 +167,15 @@ typedef enum GX2ChannelMask
    GX2_CHANNEL_MASK_RGBA = 15,
 } GX2ChannelMask;
 
+typedef enum GX2ContextStateFlags
+{
+   GX2_CONTEXT_STATE_FLAGS_NONE                   = 0,
+   GX2_CONTEXT_STATE_FLAGS_PROFILING_ENABLED      = 1 << 0,
+   GX2_CONTEXT_STATE_FLAGS_NO_SHADOW_DISPLAY_LIST = 1 << 1,
+} GX2ContextStateFlags;
+
+WUT_ENUM_BITMASK_TYPE(GX2ContextStateFlags)
+
 typedef enum GX2ClearFlags
 {
    GX2_CLEAR_FLAGS_DEPTH   = 1,


### PR DESCRIPTION
From https://github.com/decaf-emu/decaf-emu/blob/e6c528a20a41c34e0f9eb91dd3da40f119db2dee/src/libdecaf/src/cafe/libraries/gx2/gx2_enum.h#L161-L164.
Will break compiling homebrew passing the `BOOL` types `TRUE` and `FALSE` to the enum.