### PR TITLE
Add all padscore functions.

### DIFF
--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -15,6 +15,16 @@
 extern "C" {
 #endif
 
+/**
+ * Button repeat flag.
+ *
+ * \sa
+ * - `KPADRead()`
+ * - `KPADReadEx()`
+ * - `KPADSetBtnRepeat()`
+ */
+#define KPAD_BUTTON_REPEAT 0x80000000u
+
 //! Wii Remote channel.
 typedef enum WPADChan KPADChan;
 //! Data format.
@@ -38,10 +48,6 @@ typedef enum KPADButtonProcMode
    //! Make `KPADRead()` track all button changes.
    KPAD_BUTTON_PROC_MODE_TIGHT = 1,
 } KPADButtonProcMode;
-
-typedef enum KPADButtonRepeatType {
-   KPAD_BUTTON_REPEAT = 0x80000000u,
-} KPADButtonRepeatType;
 
 //! Status codes for `KPADControlDpdCallback`.
 typedef enum KPADControlDpdStatus {
@@ -944,7 +950,7 @@ KPADGetButtonProcMode(KPADChan chan);
  *
  * \param chan The target wiimote.
  * \param rotation Pointer to store the rotation.
- * \param dir_angle Pointer to store direction angle.
+ * \param dirAngle Pointer to store direction angle.
  * \param neutral Pointer to store the neutral radius.
  *
  * \sa
@@ -955,7 +961,7 @@ KPADGetButtonProcMode(KPADChan chan);
 void
 KPADGetCrossStickEmulationParamsL(KPADChan chan,
                                   float *rotation,
-                                  float *dir_angle,
+                                  float *dirAngle,
                                   float *neutral);
 
 /**
@@ -963,7 +969,7 @@ KPADGetCrossStickEmulationParamsL(KPADChan chan,
  *
  * \param chan The target wiimote.
  * \param rotation Pointer to store the rotation.
- * \param dir_angle Pointer to store the direction angle.
+ * \param dirAngle Pointer to store the direction angle.
  * \param neutral Pointer to store the neutral radius.
  *
  * \sa
@@ -974,7 +980,7 @@ KPADGetCrossStickEmulationParamsL(KPADChan chan,
 void
 KPADGetCrossStickEmulationParamsR(KPADChan chan,
                                   float *rotation,
-                                  float *dir_angle,
+                                  float *dirAngle,
                                   float *neutral);
 
 /**
@@ -1146,7 +1152,7 @@ KPADGetPosPlayMode(KPADChan chan);
  * \param dst Pointer to store the calculated position.
  * \param src Pointer to the normalized (between -1 and 1) source point.
  * \param screen Pointer to a rectangle representing the screen boundary.
- * \param pixel_ratio Correction factor for pixel ratio (1.0f for square pixels).
+ * \param pixelRatio Correction factor for pixel ratio (1.0f for square pixels).
  *
  * \sa
  * - `KPADDisableAimingMode()`
@@ -1158,7 +1164,7 @@ void
 KPADGetProjectionPos(KPADVec2D *dst,
                      const KPADVec2D *src,
                      const KPADRect *screen,
-                     float pixel_ratio);
+                     float pixelRatio);
 
 /**
  * Gets the pitch angle offset for the Nunchuk's orientation.
@@ -1439,7 +1445,7 @@ KPADSetControlDpdCallback(KPADChan chan,
  *
  * \param chan The target wiimote.
  * \param rotation The rotation parameter, in degrees.
- * \param dir_angle The direction angle parameter, as degrees, in `[0, 90]`.
+ * \param dirAngle The direction angle parameter, as degrees, in `[0, 90]`.
  * \param neutral The neutral radius parameter, in `[0, 1]`.
  *
  * \sa
@@ -1450,7 +1456,7 @@ KPADSetControlDpdCallback(KPADChan chan,
 void
 KPADSetCrossStickEmulationParamsL(KPADChan chan,
                                   float rotation,
-                                  float dir_angle,
+                                  float dirAngle,
                                   float neutral);
 
 /**
@@ -1458,7 +1464,7 @@ KPADSetCrossStickEmulationParamsL(KPADChan chan,
  *
  * \param chan The target wiimote.
  * \param rotation The rotation parameter, in degrees.
- * \param dir_angle The direction angle parameter, as degrees, in `[0, 90]`.
+ * \param dirAngle The direction angle parameter, as degrees, in `[0, 90]`.
  * \param neutral The neutral radius parameter, in `[0, 1]`.
  *
  * \sa
@@ -1469,7 +1475,7 @@ KPADSetCrossStickEmulationParamsL(KPADChan chan,
 void
 KPADSetCrossStickEmulationParamsR(KPADChan chan,
                                   float rotation,
-                                  float dir_angle,
+                                  float dirAngle,
                                   float neutral);
 
 /**
@@ -1647,15 +1653,15 @@ KPADSetMplsDpdReviseParam(KPADChan chan,
  * Sets the MotionPlus angular speed scales.
  *
  * \param chan The target wiimote.
- * \param scale_pitch Scale applied to the pitch speed.
- * \param scale_yaw Scale applied to the yaw speed.
- * \param scale_roll Scale applied to the roll speed.
+ * \param scalePitch Scale applied to the pitch speed.
+ * \param scaleYaw Scale applied to the yaw speed.
+ * \param scaleRoll Scale applied to the roll speed.
  */
 void
 KPADSetMplsMagnification(KPADChan chan,
-                         float scale_pitch,
-                         float scale_yaw,
-                         float scale_roll);
+                         float scalePitch,
+                         float scaleYaw,
+                         float scaleRoll);
 
 /**
  * Sets the MotionPlus zero drift mode.

--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -147,8 +147,8 @@ struct KPADRect
    KPADVec2D topLeft;
    KPADVec2D bottomRight;
 };
-WUT_CHECK_OFFSET(KPADRect, 0x00, top_left);
-WUT_CHECK_OFFSET(KPADRect, 0x08, bottom_right);
+WUT_CHECK_OFFSET(KPADRect, 0x00, topLeft);
+WUT_CHECK_OFFSET(KPADRect, 0x08, bottomRight);
 WUT_CHECK_SIZE(KPADRect, 0x10);
 
 //! A structure containing the Wii Remote data.

--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <wut.h>
 #include <padscore/wpad.h>
+#include <padscore/wbc.h>
 
 /**
  * \defgroup padscore_kpad KPAD
@@ -23,10 +24,30 @@ typedef enum WPADExtensionType KPADExtensionType;
 //! MotionPlus Mode.
 typedef enum WPADMplsMode KPADMplsMode;
 
+typedef struct KPADBase3D KPADBase3D;
+typedef struct KPADRect KPADRect;
 typedef struct KPADStatus KPADStatus;
 typedef struct KPADUnifiedWpadStatus KPADUnifiedWpadStatus;
 typedef struct KPADVec2D KPADVec2D;
 typedef struct KPADVec3D KPADVec3D;
+
+typedef enum KPADButtonProcMode
+{
+   //! Make `KPADRead()` track only the most recent button state. This is the default.
+   KPAD_BUTTON_PROC_MODE_LOOSE = 0,
+   //! Make `KPADRead()` track all button changes.
+   KPAD_BUTTON_PROC_MODE_TIGHT = 1,
+} KPADButtonProcMode;
+
+typedef enum KPADButtonRepeatType {
+   KPAD_BUTTON_REPEAT = 0x80000000u,
+} KPADButtonRepeatType;
+
+//! Status codes for `KPADControlDpdCallback`.
+typedef enum KPADControlDpdStatus {
+   KPAD_CONTROL_DPD_STATUS_STARTED  = 0,
+   KPAD_CONTROL_DPD_STATUS_FINISHED = 1,
+} KPADControlDpdStatus;
 
 //! Error.
 typedef enum KPADError
@@ -60,6 +81,19 @@ typedef enum KPADControlMplsStatus
    KPAD_CONTROL_MPLS_STATUS_FAILED_MPLS_CLASSIC = -3,
 } KPADControlMplsStatus;
 
+typedef enum KPADMplsZeroDriftMode {
+   KPAD_MPLS_ZERO_DRIFT_MODE_LOOSE,
+   KPAD_MPLS_ZERO_DRIFT_MODE_STANDARD,
+   KPAD_MPLS_ZERO_DRIFT_MODE_TIGHT,
+} KPADMplsZeroDriftMode;
+
+typedef enum KPADPlayMode {
+   //! Use a smoothing filter.
+   KPAD_PLAY_MODE_LOOSE = 0,
+   //! Use a sharper, more responsive filter.
+   KPAD_PLAY_MODE_TIGHT = 1,
+} KPADPlayMode;
+
 //! 2D vector.
 struct KPADVec2D
 {
@@ -86,6 +120,25 @@ WUT_CHECK_OFFSET(KPADVec3D, 0x00, x);
 WUT_CHECK_OFFSET(KPADVec3D, 0x04, y);
 WUT_CHECK_OFFSET(KPADVec3D, 0x08, z);
 WUT_CHECK_SIZE(KPADVec3D, 0x0C);
+
+struct KPADBase3D {
+   KPADVec3D x;
+   KPADVec3D y;
+   KPADVec3D z;
+};
+WUT_CHECK_OFFSET(KPADBase3D, 0x00, x);
+WUT_CHECK_OFFSET(KPADBase3D, 0x0C, y);
+WUT_CHECK_OFFSET(KPADBase3D, 0x18, z);
+WUT_CHECK_SIZE(KPADBase3D, 0x24);
+
+//! 2D rectangle.
+struct KPADRect {
+   KPADVec2D top_left;
+   KPADVec2D bottom_right;
+};
+WUT_CHECK_OFFSET(KPADRect, 0x00, top_left);
+WUT_CHECK_OFFSET(KPADRect, 0x08, bottom_right);
+WUT_CHECK_SIZE(KPADRect, 0x10);
 
 //! A structure containing the Wii Remote data.
 struct KPADStatus
@@ -141,7 +194,7 @@ struct KPADStatus
    //! Value from KPADExtensionType.
    uint8_t extensionType;
 
-   //! Value from KPADError.
+   //! Value from WPADError.
    int8_t error;
 
    //! Validity of the `pos` field.
@@ -226,7 +279,7 @@ struct KPADStatus
          //! Time-smoothed uncorrected weights, very slow to stabilize.
          double avgWeights[WPAD_MAX_PRESSURE_SENSORS];
          //! Error generated from reading weights.
-         int32_t error;
+         WBCError error;
          //! Status of calibration: negative is error, otherwise is [0, 3], but KPAD never
          //! reaches level 3.
          int32_t calibration;
@@ -240,12 +293,8 @@ struct KPADStatus
       KPADVec3D acc;
       //! Computed angles integrated from acceleration.
       KPADVec3D angles;
-      //! Computed X direction vector.
-      KPADVec3D dirX;
-      //! Computed Y direction vector.
-      KPADVec3D dirY;
-      //! Computed Z direction vector.
-      KPADVec3D dirZ;
+      //! Computed directions.
+      KPADBase3D dir;
    } mplus;
 
    WUT_PADDING_BYTES(4);
@@ -303,9 +352,7 @@ WUT_CHECK_OFFSET(KPADStatus, 0xAC, balance.calibration);
 // MotionPlus fields.
 WUT_CHECK_OFFSET(KPADStatus, 0xB0, mplus.acc);
 WUT_CHECK_OFFSET(KPADStatus, 0xBC, mplus.angles);
-WUT_CHECK_OFFSET(KPADStatus, 0xC8, mplus.dirX);
-WUT_CHECK_OFFSET(KPADStatus, 0xD4, mplus.dirY);
-WUT_CHECK_OFFSET(KPADStatus, 0xE0, mplus.dirZ);
+WUT_CHECK_OFFSET(KPADStatus, 0xC8, mplus.dir);
 WUT_CHECK_SIZE(KPADStatus, 0xF0);
 
 /**
@@ -342,19 +389,40 @@ WUT_CHECK_SIZE(KPADUnifiedWpadStatus, 0x44);
 typedef WPADConnectCallback KPADConnectCallback;
 typedef WPADSamplingCallback KPADSamplingCallback;
 
+/**
+ * Callback for receiving notifications about IR state changes.
+ *
+ * \sa
+ * - `KPADDisableDPD()`
+ * - `KPADEnableDPD()`
+ * - `KPADSetControlDpdCallback()`
+ */
+typedef void (*KPADControlDpdCallback)(KPADChan chan, KPADControlDpdStatus status);
+
 //! Callback used for `KPADSetControlMplsCallback()`.
 typedef void (*KPADControlMplsCallback)(KPADChan chan, KPADControlMplsStatus status);
 
 /**
- * Initialises the KPAD library for use.
+ * Initializes the KPAD library for use.
  *
- * Note: this calls `KPADInitEx(NULL, 0)`.
+ * \note This calls `KPADInitEx(NULL, 0)`.
+ *
+ * \sa
+ * - `KPADInitEx()`
  */
 void
 KPADInit(void);
 
 /**
  * Initializes the KPAD library with extra buffers.
+ *
+ * \param buffer Additional buffer to store data.
+ * \param count How many entries exist in the buffer. Should be multiple of the maximum
+ *              number of controllers.
+ *
+ * \sa
+ * - `KPADInit()`
+ * - `KPADSetMaxControllers()`
  */
 void
 KPADInitEx(KPADUnifiedWpadStatus *buffer,
@@ -369,49 +437,77 @@ KPADShutdown(void);
 /**
  * Read data from the desired controller.
  *
+ * \note
+ * When the button processing mode is `KPAD_BUTTON_PROC_MODE_LOOSE` (the default) all
+ * samples have the same button data, corresponding to the most recent button
+ * state. Button activity between `KPADRead()` calls are discarded.
+ *
  * \param chan
  * The channel of the controller to read from.
  *
  * \param data
- * The KPADStatus to fill.
+ * The KPADStatus to fill with samples, from newest to oldest.
  *
- * \param size
- * The maximum number of data to read.
+ * \param count
+ * The maximum number of data samples to read.
  *
  * \return
- * The number of data read.
+ * The number of data samples read.
+ *
+ * \sa
+ * - `KPADGetButtonProcMode()`
+ * - `KPADReadEx()`
+ * - `KPADSetButtonProcMode()`
  */
 uint32_t
 KPADRead(KPADChan chan,
          KPADStatus *data,
-         uint32_t size);
+         uint32_t count);
 
 /**
- * Read data from the desired controller.
+ * Read data from the desired controller, and retrieve error status.
+ *
+ * \note
+ * When the button processing mode is `KPAD_BUTTON_PROC_MODE_LOOSE` (the default) all
+ * samples have the same button data, corresponding to the most recent button
+ * state. Button activity between `KPADReadEx()` calls are discarded.
  *
  * \param chan
  * The channel of the controller to read from.
  *
  * \param data
- * The KPADStatus to fill.
+ * The KPADStatus to fill with samples, from newest to oldest.
  *
- * \param size
- * The maximum number of data to read.
+ * \param count
+ * The maximum number of data samples to read.
  *
  * \param error
- * A pointer to an error code.
+ * A pointer to store an error code.
  *
  * \return
- * The number of data read.
+ * The number of data samples read.
+ *
+ * \sa
+ * - `KPADGetButtonProcMode()`
+ * - `KPADRead()`
+ * - `KPADSetButtonProcMode()`
  */
 uint32_t
 KPADReadEx(KPADChan chan,
            KPADStatus *data,
-           uint32_t size,
+           uint32_t count,
            KPADError *error);
 
 /**
  * Read a number of entries from the internal buffer.
+ *
+ * \param chan The target wiimote.
+ * \param buffer The destination buffer.
+ * \param count The number of entries that will be copied.
+ *
+ * \sa
+ * - `KPADRead()`
+ * - `KPADUnifiedWpadStatus`
  */
 void
 KPADGetUnifiedWpadStatus(KPADChan chan,
@@ -419,37 +515,51 @@ KPADGetUnifiedWpadStatus(KPADChan chan,
                          uint32_t count);
 
 /**
- * Set the maximum amount of controllers which can be connected to the system.
+ * Sets the maximum amount of controllers which can be connected to the system.
  *
  * \param maxControllers
- * The maximum amount of controllers. Must be \c 4 or \c 7.
+ * The maximum amount of controllers. Must be `4` or `7`.
  *
  * \return
- * 0 on success.
+ * `0` on success.
+ *
+ * \sa
+ * - `KPADGetGameMaxControllers()`
+ * - `KPADGetMaxControllers()`
  */
 int32_t
 KPADSetMaxControllers(uint32_t maxControllers);
 
 /**
- * Get the maximum amount of controllers which can be connected to the system.
+ * Gets the maximum amount of controllers which can be connected to the system.
  *
  * \return
  * The maximum amount of controllers.
+ *
+ * \sa
+ * - `KPADGetGameMaxControllers()`
+ * - `KPADSetMaxControllers()`
  */
 uint32_t
 KPADGetMaxControllers(void);
 
 /**
- * Get the maximum amount of controllers which can be connected, as reported by IOS-PAD.
+ * Gets the maximum amount of controllers which can be connected, as reported by IOS-PAD.
  *
  * \return
  * The maximum amount of controllers.
+ *
+ * \sa
+ * - `KPADGetMaxControllers()`
+ * - `KPADSetMaxControllers()`
  */
 uint32_t
 KPADGetGameMaxControllers(void);
 
 /**
- * Set a callback for when a controller connection status changes.
+ * Sets a callback for when a controller connection status changes.
+ *
+ * \note Do not call `WPADSetConnectCallback()` if you call this.
  *
  * \param chan
  * The channel of the controller to set a callback for.
@@ -465,33 +575,51 @@ KPADSetConnectCallback(KPADChan chan,
                        KPADConnectCallback callback);
 
 /**
- * Same usage as \link WPADSetSamplingCallback\endlink, except compatible with other KPAD functions
+ * Sets a sampling callback.
+ *
+ * \note Same usage as `WPADSetSamplingCallback()`, except compatible with other KPAD
+ *       functions.
+ *
+ * \param chan The target wiimote.
+ *
+ * \param callback The callback that will be called whenever the wiimote communicates, or
+ *                 `NULL`.
+ *
+ * \return The old callback.
  */
 KPADSamplingCallback
-KPADSetSamplingCallback(KPADChan channel,
+KPADSetSamplingCallback(KPADChan chan,
                         KPADSamplingCallback callback);
 
 /**
- * Returns the amount of memory needed for `KPADSetMplsWorkarea()`.
+ * Returns the amount of extra memory needed for MotionPlus handling.
+ *
+ * \return How many bytes need to be allocated and set with `KPADSetMplsWorkarea()`.
+ *
+ * \sa
+ * - `KPADSetMplsWorkarea()`
  */
 uint32_t
 KPADGetMplsWorkSize(void);
 
 /**
- * Sets the extra memory KPAD will use to process MotionPlus data.
+ * Sets the extra memory needed to process MotionPlus data.
  *
  * Without this work area, the `mplus` field in `KPADStatus` will be filled with zeros.
  *
  * \param buf A memory buffer with size obtained from `KPADGetMplsWorkSize()`.
+ *
+ * \sa
+ * - `KPADGetMplsWorkSize()`
  */
 void
 KPADSetMplsWorkarea(void *buf);
 
 /**
- * Set a callback for when the MotionPlus extension is configured.
+ * Sets a callback for when the MotionPlus extension is configured.
  *
  * \param chan Controller channel to set the callback for.
- * \param callback Pointer to callback functio that will be invoked.
+ * \param callback Pointer to callback function that will be invoked.
  *
  * \sa
  * - `KPADEnableMpls()`
@@ -510,6 +638,9 @@ KPADSetControlMplsCallback(KPADChan chan,
  * \link KPADGetMplsStatus \endlink
  *
  * \sa
+ * - `KPADDisableMpls()`
+ * - `KPADGetMplsStatus()`
+ * - `KPADSetConnectCallback()`
  * - `KPADSetControlMplsCallback()`
  */
 void
@@ -518,20 +649,45 @@ KPADEnableMpls(KPADChan channel,
 
 /**
  * Disables MotionPlus for the controller
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADEnableMpls()`
  */
 void
-KPADDisableMpls(KPADChan channel);
+KPADDisableMpls(KPADChan chan);
 
 /**
- * Get MotionPlus mode
+ * Gets MotionPlus mode
  *
- * identical to \ref WPADiGetMplsStatus
+ * \param chan The target wiimote.
+ *
+ * \return One of the `WPAD_MPLS_MODE_*` values.
+ *
+ * \sa
+ * - `WPADiGetMplsStatus()`
  */
 KPADMplsMode
 KPADGetMplsStatus(KPADChan chan);
 
 /**
+ * Resets some controller state, like rumble motor, button state, etc.
+ *
+ * \note Some of the reset happens on the next `KPADRead()`.
+ */
+void
+KPADReset(void);
+
+/**
  * Resets the MotionPlus state.
+ *
+ * \note If MotionPlus is enabled, this is called by `KPADReset()`.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADReset()`
  */
 void
 KPADResetMpls(KPADChan chan);
@@ -543,22 +699,1105 @@ void
 KPADEnableDPD(KPADChan chan);
 
 /**
- * Disable IR pointing
+ * Disables IR pointing.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADEnableDPD()`
  */
 void
 KPADDisableDPD(KPADChan chan);
 
 /**
  * Resets the Balance Board's zero.
+ *
+ * \note This is called by `KPADResetWbcTgcWeight()`.
  */
 void
 KPADResetWbcZeroPoint(void);
 
 /**
- * Recalculate the Balance Board's TGC coefficients and zero.
+ * Recalculates the Balance Board's TGC coefficients and zero.
+ *
+ * \note This is called by `KPADInit()/KPADInitEx()`.
+ *
+ * \sa
+ * - `KPADInit()`
+ * - `KPADInitEx()`
  */
 void
 KPADResetWbcTgcWeight(void);
+
+/**
+ * Recalibrates horizontal position for wiimote.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return The number of IR points detected: if `2`, the calibration was performed, any
+ *         other value (including `-1`) indicates an error.
+ */
+int32_t
+KPADCalibrateDPD(KPADChan chan);
+
+/**
+ * Disables TV aiming mode.
+ *
+ * Makes the origin `(0, 0)` the center of the sensor bar.
+ *
+ * \param chan The wiimote channel
+ *
+ * \sa
+ * - `KPADEnableAimingMode()`
+ * - `KPADGetProjectionPos()`
+ * - `KPADGetSensorHeight()`
+ * - `KPADIsEnableAimingMode()`
+ */
+void
+KPADDisableAimingMode(KPADChan chan);
+
+/**
+ * Disables MotionPlus accelerometer correction.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADEnableMplsAccRevise()`
+ * - `KPADIsEnableMplsAccRevise()`
+ */
+void
+KPADDisableMplsAccRevise(KPADChan chan);
+
+/**
+ * Disables MotionPlus direction correction.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADEnableMplsDirRevise()`
+ * - `KPADIsEnableMplsDirRevise()`
+ */
+void
+KPADDisableMplsDirRevise(KPADChan chan);
+
+/**
+ * Disables MotionPlus IR pointing correction.
+ *
+ * This is enabled by default.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADEnableMplsDpdRevise()`
+ * - `KPADIsEnableMplsDpdRevise()`
+ */
+void
+KPADDisableMplsDpdRevise(KPADChan chan);
+
+/**
+ * Disables the MotionPlus zero play tolerance.
+ *
+ * This is disabled by default.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADEnableMplsZeroPlay()`
+ * - `KPADIsEnableMplsZeroPlay()`
+ */
+void
+KPADDisableMplsZeroPlay(KPADChan chan);
+
+/**
+ * Disables cross clamping for sticks.
+ *
+ * This is disabled by default.
+ *
+ * \sa
+ * - `KPADEnableStickCrossClamp()`
+ */
+void
+KPADDisableStickCrossClamp();
+
+/**
+ * Enables TV aiming mode.
+ *
+ * Makes the origin `(0, 0)` the center of the TV. This is enabled by default.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADDisableAimingMode()`
+ * - `KPADGetProjectionPos()`
+ * - `KPADGetSensorHeight()`
+ * - `KPADIsEnableAimingMode()`
+ */
+void
+KPADEnableAimingMode(KPADChan chan);
+
+/**
+ * Enables MotionPlus accelerometer correction.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADDisableMplsAccRevise()`
+ * - `KPADIsEnableMplsAccRevise()`
+ */
+void
+KPADEnableMplsAccRevise(KPADChan chan);
+
+/**
+ * Enables MotionPlus direction correction.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADDisableMplsDirRevise()`
+ * - `KPADIsEnableMplsDirRevise()`
+ */
+void
+KPADEnableMplsDirRevise(KPADChan chan);
+
+/**
+ * Enables MotionPlus IR pointing correction.
+ *
+ * This is enabled by default.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADDisableMplsDpdRevise()`
+ * - `KPADIsEnableMplsDpdRevise()`
+ */
+void
+KPADEnableMplsDpdRevise(KPADChan chan);
+
+/**
+ * Enables MotionPlus zero play tolerance.
+ *
+ * This is disabled by default.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADDisableMplsZeroPlay()`
+ * - `KPADIsEnableMplsZeroPlay()`
+ */
+void
+KPADEnableMplsZeroPlay(KPADChan chan);
+
+/**
+ * Enables cross clamping or sticks.
+ *
+ * This is disabled by default.
+ *
+ * \sa
+ * - `KPADDisableStickCrossClamp()`
+ */
+void
+KPADEnableStickCrossClamp(void);
+
+/**
+ * Gets the accelerometer parameters (tolerance and sensitivity.)
+ *
+ * \param chan The target wiimote.
+ * \param tolerance Pointer to store the tolerance.
+ * \param sensitivity Pointer to store the sensitivity.
+ *
+ * \ sa
+ * - `KPADSetAccParam()`
+ */
+void
+KPADGetAccParam(KPADChan chan,
+                float *tolerance,
+                float *sensitivity);
+
+/**
+ * Gets the accelrometer play mode.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return The accelerometer play mode.
+ *
+ * \sa
+ * - `KPADSetAccPlayMode()`
+ */
+KPADPlayMode
+KPADGetAccPlayMode(KPADChan chan);
+
+/**
+ * Gets the button processing mode.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADRead()`
+ * - `KPADReadEx()`
+ * - `KPADSetButtonProcMode()`
+ */
+KPADButtonProcMode
+KPADGetButtonProcMode(KPADChan chan);
+
+/**
+ * Gets the cross stick emulation parameters for the left stick.
+ *
+ * \param chan The target wiimote.
+ * \param rotation Pointer to store the rotation.
+ * \param dir_angle Pointer to store direction angle.
+ * \param neutral Pointer to store the neutral radius.
+ *
+ * \sa
+ * - `KPADGetCrossStickEmulationParamsR()`
+ * - `KPADSetCrossStickEmulationParamsL()`
+ * - `KPADSetCrossStickEmulationParamsR()`
+ */
+void
+KPADGetCrossStickEmulationParamsL(KPADChan chan,
+                                  float *rotation,
+                                  float *dir_angle,
+                                  float *neutral);
+
+/**
+ * Gets the cross stick emulation parameters for the right stick.
+ *
+ * \param chan The target wiimote.
+ * \param rotation Pointer to store the rotation.
+ * \param dir_angle Pointer to store the direction angle.
+ * \param neutral Pointer to store the neutral radius.
+ *
+ * \sa
+ * - `KPADGetCrossStickEmulationParamsL()`
+ * - `KPADSetCrossStickEmulationParamsL()`
+ * - `KPADSetCrossStickEmulationParamsR()`
+ */
+void
+KPADGetCrossStickEmulationParamsR(KPADChan chan,
+                                  float *rotation,
+                                  float *dir_angle,
+                                  float *neutral);
+
+/**
+ * Gets the IR pointer's distance parameters.
+ *
+ * \param chan The target wiimote.
+ * \param tolerance Pointer to store the tolerance.
+ * \param sensitivity Pointer to store the sensitivity.
+ *
+ * \sa
+ * - `KPADSetDistParam()`
+ */
+void
+KPADGetDistParam(KPADChan chan,
+                 float *tolerance,
+                 float *sensitivity);
+
+/**
+ * Gets the IR pointer's distance play mode.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return The mode used by the distance tracking.
+ *
+ * \sa
+ * - `KPADSetDistPlayMode()`
+ */
+KPADPlayMode
+KPADGetDistPlayMode(KPADChan chan);
+
+/**
+ * Gets the current IR detection mode.
+ *
+ * \return The current mode.
+ *
+ * \sa
+ * - `KPADSetDpdDetection()`
+ */
+uint8_t
+KPADGetDpdDetection(void);
+
+/**
+ * Gets the IR pointer's horizon parameters.
+ *
+ * \param chan The target wiimote.
+ * \param tolerance Pointer to store the tolerance.
+ * \param sensitivity Pointer to store the sensitivity.
+ *
+ * \sa
+ * - `KPADSetHoriParam()`
+ */
+void
+KPADGetHoriParam(KPADChan chan,
+                 float *tolerance,
+                 float *sensitivity);
+
+/**
+ * Gets the IR pointer's horizon play mode.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return The mode used by the horizon tracking.
+ *
+ * \sa
+ * - `KPADSetHoriPlayMode()`
+ */
+KPADPlayMode
+KPADGetHoriPlayMode(KPADChan chan);
+
+/**
+ * Gets the MotionPlus acceleration correction parameters.
+ *
+ * \param chan The target wiimote.
+ * \param weight Pointer to store the weight.
+ * \param range Pointer to store the range.
+ *
+ * \sa
+ * - `KPADInitMplsAccReviseParam()`
+ * - `KPADSetMplsAccReviseParam()`
+ */
+void
+KPADGetMplsAccReviseParam(KPADChan chan,
+                          float *weight,
+                          float *range);
+
+/**
+ * Gets the MotionPlus direction correction weight parameter.
+ *
+ * \param chan The target wiimote.
+ * \param weight Pointer to store the weight.
+ *
+ * \sa
+ * - `KPADInitMplsDirReviseParam()`
+ * - `KPADSetMplsDirReviseParam()`
+ */
+void
+KPADGetMplsDirReviseParam(KPADChan chan,
+                          float *weight);
+
+/**
+ * Gets the MotionPlus IR pointer correction weight parameter.
+ *
+ * \param chan The target wiimote.
+ * \param weight Pointer to store the weight.
+ */
+void
+KPADGetMplsDpdReviseParam(KPADChan chan,
+                          float *weight);
+
+/**
+ * Gets the MotionPlus zero drift mode.
+ *
+ * \param chan The target wiimote.
+ * \param mode Pointer to store the zero drift mode.
+ *
+ * \sa
+ * - `KPADSetMplsZeroDriftMode()`
+ * - `KPADInitMplsZeroDriftMode()`
+ */
+void
+KPADGetMplsZeroDriftMode(KPADChan chan,
+                         KPADMplsZeroDriftMode *mode);
+
+/**
+ * Gets the MotionPlus zero play tolerance parameter.
+ *
+ * \param chan The target wiimote.
+ * \param tolerance Pointer to store the tolerance.
+ *
+ * \sa
+ * - `KPADSetMplsZeroPlayParam()`
+ * - `KPADInitMplsZeroPlayParam()`
+ */
+void
+KPADGetMplsZeroPlayParam(KPADChan chan,
+                         float *tolerance);
+
+/**
+ * Gets the IR pointer's position parameters.
+ *
+ * \param chan The target wiimote.
+ * \param tolerance Pointer to store the tolerance.
+ * \param sensitivity Pointer to store the sensitivity.
+ *
+ * \sa
+ * - `KPADSetPosParam()`
+ */
+void
+KPADGetPosParam(KPADChan chan,
+                float *tolerance,
+                float *sensitivity);
+
+/**
+ * Gets the IR pointer's position play mode.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return The position play mode.
+ *
+ * \sa
+ * - `KPADSetPosPlayMode()`
+ */
+KPADPlayMode
+KPADGetPosPlayMode(KPADChan chan);
+
+/**
+ * Transforms a normalized point to pixel coordinates.
+ *
+ * \param dst Pointer to store the calculated position.
+ * \param src Pointer to the normalized (between -1 and 1) source point.
+ * \param screen Pointer to a rectangle representing the screen boundary.
+ * \param pixel_ratio Correction factor for pixel ratio (1.0f for square pixels).
+ *
+ * \sa
+ * - `KPADDisableAimingMode()`
+ * - `KPADEnableAimingMode()`
+ * - `KPADGetSensorHeight()`
+ * - `KPADGetSensorHeight()`
+ */
+void
+KPADGetProjectionPos(KPADVec2D *dst,
+                     const KPADVec2D *src,
+                     const KPADRect *screen,
+                     float pixel_ratio);
+
+/**
+ * Gets the pitch angle offset for the Nunchuk's orientation.
+ *
+ * The angle is taken counter-clockwise around the X axis, in degrees.
+ *
+ * \return The offset pitch angle offset applied to the Nunchuk, in degrees.
+ *
+ * \sa
+ * - `KPADReviseAcc()`
+ * - `KPADSetReviseMode()`
+ */
+float
+KPADGetReviseAngle(void);
+
+/**
+ * Gets the sensor bar height.
+ *
+ * \param chan The target wiimote.
+ *
+ * \result The sensor bar height.
+ *
+ * \sa
+ * - `KPADDisableAimingMode()`
+ * - `KPADEnableAimingMode()`
+ * - `KPADGetProjectionPos()`
+ * - `KPADSetSensorHeight()`
+ */
+float
+KPADGetSensorHeight(KPADChan chan);
+
+/**
+ * Initializes the MotionPlus acceleration correction parameters.
+ *
+ * The parameters are initialized:
+ * - `weight = 0.03f`
+ * - `range = 0.4f`
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADGetMplsAccReviseParam()`
+ * - `KPADSetMplsAccReviseParam()`
+ */
+void
+KPADInitMplsAccReviseParam(KPADChan chan);
+
+/**
+ * Initializes the MotionPlus orientation correction weight parameter.
+ *
+ * The weight is initialized to `0.5f`.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADGetMplsDirReviseParam()`
+ * - `KPADSetMplsDirReviseParam()`
+ */
+void
+KPADInitMplsDirReviseParam(KPADChan chan);
+
+/**
+ * Initializes the MotionPlus IR pointer correction weight parameter.
+ *
+ * The weight is initialized to `0.05f`.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADGetMplsDpdReviseParam()`
+ * - `KPADSetMplsDpdReviseParam()`
+ */
+void
+KPADInitMplsDpdReviseParam(KPADChan chan);
+
+/**
+ * Initializes the MotionPlus zero drift mode.
+ *
+ * The mode is initialized to `KPAD_MPLS_ZERO_DRIFT_MODE_STANDARD`.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADGetMplsZeroDriftMode()`
+ * - `KPADSetMplsZeroDriftMode()`
+ */
+void
+KPADInitMplsZeroDriftMode(KPADChan chan);
+
+/**
+ * Initializes the MotionPlus zero play tolerance.
+ *
+ * The tolerance is initialized to `0.005f`.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADGetMplsZeroPlayParam()`
+ * - `KPADSetMplsZeroPlayParam()`
+ */
+void
+KPADInitMplsZeroPlayParam(KPADChan chan);
+
+/**
+ * Returns the state of aiming mode.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return `TRUE` if aiming mode is enabled, `FALSE` otherwise.
+ *
+ * \sa
+ * - `KPADDisableAimingMode()`
+ * - `KPADEnableAimingMode()`
+ */
+BOOL
+KPADIsEnableAimingMode(KPADChan chan);
+
+/**
+ * Returns the state of MotionPlus acceleration correction parameter.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return `-1` if the correction is disabled, or the correction parameter when enabled.
+ *
+ * \sa
+ * - `KPADDisableMplsAccRevise()`
+ * - `KPADEnableMplsAccRevise()`
+ */
+float
+KPADIsEnableMplsAccRevise(KPADChan chan);
+
+/**
+ * Returns the state of the MotionPlus direction correction parameter.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return `-1` if the correction is disabled, or the correction parameter when enabled.
+ *
+ * \sa
+ * - `KPADDisableMplsDirRevise()`
+ * - `KPADEnableMplsDirRevise()`
+ */
+float
+KPADIsEnableMplsDirRevise(KPADChan chan);
+
+/**
+ * Returns the state of the MotionPlus IR pointer correction parameter.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return `-1` if the correction is disabled, or the correction parameter when enabled.
+ *
+ * \sa
+ * - `KPADDisableMplsDpdRevise()`
+ * - `KPADEnableMplsDpdRevise()`
+ */
+float
+KPADIsEnableMplsDpdRevise(KPADChan chan);
+
+/**
+ * Returns the state of the MotionPlus zero drift correction.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return `-1` if the correction is disabled, or the current correction value.
+ */
+float
+KPADIsEnableMplsZeroDrift(KPADChan chan);
+
+/**
+ * Returns the state of the MotionPlus zero play correction.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return `-1` if the correction is disabled, or the current correction value.
+ *
+ * \sa
+ * - `KPADDisableMplsZeroPlay()`
+ * - `KPADEnableMplsZeroPlay()`
+ */
+float
+KPADIsEnableMplsZeroPlay(KPADChan chan);
+
+/**
+ * Transforms the argument by the Nunchuk's pitch correction angle.
+ *
+ * \param vec The 3D vector to be transformed by the correction angle, around the X axis.
+ *
+ * \return The angle that was used to rotate the argument, degrees.
+ *
+ * \sa
+ * - `KPADGetReviseAngle()`
+ * - `KPADSetReviseMode()`
+ */
+float
+KPADReviseAcc(KPADVec3D *vec);
+
+/**
+ * Sets the accelerometer tolerance and sensitivity parameters.
+ *
+ * \param chan The target wiimote.
+ * \param tolerance The play tolerance, `>= 0`. Default value is `0`.
+ * \param sensitivity The sensitivity, in `[0, 1]`. Default value is `1`.
+ *
+ * \sa
+ * - `KPADGetAccParam()`
+ */
+void
+KPADSetAccParam(KPADChan chan,
+                float tolerance,
+                float sensitivity);
+
+/**
+ * Sets the accelerometer play mode.
+ *
+ * \param chan The target wiimote.
+ * \param mode The desired mode. `KPAD_PLAY_MODE_LOOSE` is the default.
+ *
+ * \sa
+ * - `KPADGetAccPlayMode()`
+ */
+void
+KPADSetAccPlayMode(KPADChan chan,
+                   KPADPlayMode mode);
+
+/**
+ * Sets the button repeat parameters.
+ *
+ * This sets the `KPAD_BUTTON_REPEAT` bit in the `hold` field every `pulse` seconds, after
+ * a button is held down for `delay` seconds.
+ *
+ * \note Wii U Menu uses `delay = 0.5f`, `pulse = 0.1f`.
+ *
+ * \param chan The target wiimote.
+ * \param delay How long a button needs to be held down (in seconds) before the repeat action
+ *              starts.
+ * \param pulse Interval (in seconds) between repeat pulses.
+ */
+void
+KPADSetBtnRepeat(KPADChan chan,
+                 float delay,
+                 float pulse);
+
+/**
+ * Sets the button processing mode.
+ *
+ * Use `KPAD_BUTTON_PROC_MODE_TIGHT` to track button presses in-between samples, with
+ * `KPADRead()`/`KPADReadEx()`
+ *
+ * \param chan The target wiimote.
+ * \param mode The desired processing mode. The default is `KPAD_BUTTON_PROC_MODE_LOOSE`.
+ *
+ * \sa
+ * - `KPADGetButtonProcMode()`
+ * - `KPADRead()`
+ * - `KPADReadEx()`
+ */
+void
+KPADSetButtonProcMode(KPADChan chan,
+                      KPADButtonProcMode mode);
+
+/**
+ * Sets the notification callback for IR status changes.
+ *
+ * \param chan The target wiimote.
+ * \param callback The callback that will be called when IR status changes, or `NULL`.
+ *
+ * \sa
+ * - `KPADDisableDPD()`
+ * - `KPADEnableDPD()`
+ */
+void
+KPADSetControlDpdCallback(KPADChan chan,
+                          KPADControlDpdCallback callback);
+
+/**
+ * Sets the cross stick emulation parameters for the left stick.
+ *
+ * \param chan The target wiimote.
+ * \param rotation The rotation parameter, in degrees.
+ * \param dir_angle The direction angle parameter, as degrees, in `[0, 90]`.
+ * \param neutral The neutral radius parameter, in `[0, 1]`.
+ *
+ * \sa
+ * - `KPADGetCrossStickEmulationParamsL()`
+ * - `KPADGetCrossStickEmulationParamsR()`
+ * - `KPADSetCrossStickEmulationParamsR()`
+ */
+void
+KPADSetCrossStickEmulationParamsL(KPADChan chan,
+                                  float rotation,
+                                  float dir_angle,
+                                  float neutral);
+
+/**
+ * Sets the cross stick emulation parameters for the right stick.
+ *
+ * \param chan The target wiimote.
+ * \param rotation The rotation parameter, in degrees.
+ * \param dir_angle The direction angle parameter, as degrees, in `[0, 90]`.
+ * \param neutral The neutral radius parameter, in `[0, 1]`.
+ *
+ * \sa
+ * - `KPADGetCrossStickEmulationParamsL()`
+ * - `KPADGetCrossStickEmulationParamsR()`
+ * - `KPADSetCrossStickEmulationParamsL()`
+ */
+void
+KPADSetCrossStickEmulationParamsR(KPADChan chan,
+                                  float rotation,
+                                  float dir_angle,
+                                  float neutral);
+
+/**
+ * Sets the IR distance parameters.
+ *
+ * \param chan The target wiimote.
+ * \param tolerance The amount of movement that is interpreted as stationary, default is `0`.
+ * \param sensitivity The scale used for movement, default is `1`.
+ *
+ * \sa
+ * - `KPADGetDistParam()`
+ */
+void
+KPADSetDistParam(KPADChan chan,
+                 float tolerance,
+                 float sensitivity);
+
+/**
+ * Sets the IR distance play mode.
+ *
+ * \param chan The target wiimote.
+ * \param mode The play mode used for the distance calculation. The default is
+ *             `KPAD_PLAY_MODE_LOOSE`.
+ *
+ * \sa
+ * - `KPADGetDistPlayMode()`
+ */
+void
+KPADSetDistPlayMode(KPADChan chan,
+                    KPADPlayMode mode);
+
+/**
+ * Sets IR point detection algorithm.
+ *
+ * \todo Find out exactly what changes; it is accessed during KPADRead() while processing angles.
+ *
+ * \sa
+ * - `KPADGetDpdDetection()`
+ */
+void
+KPADSetDpdDetection(uint8_t state);
+
+/**
+ * Sets the Nunchuk's stick clamp values.
+ *
+ * These values are used by KPAD to convert the `WPADStatusNunchuk` stick values to the
+ * normalized `KPADStatus` values. Values smaller than `min` are mapped to `0`, and larger
+ * than `max` to `1`.
+ *
+ * \param min Minimum absolute stick value.
+ * \param max Maximum absolute stick value.
+ */
+void
+KPADSetFSStickClamp(int8_t min,
+                    int8_t max);
+
+/**
+ * Sets the IR pointer's horizon parameters.
+ *
+ * \param chan The target wiimote.
+ * \param tolerance The tolerance parameter. Default is `0`.
+ * \param sensitivity The sensitivity parameter. Default is `1`.
+ *
+ * \sa
+ * - `KPADGetHoriParam()`
+ */
+void
+KPADSetHoriParam(KPADChan chan,
+                 float tolerance,
+                 float sensitivity);
+
+/**
+ * Sets the IR pointer's horizon play mode.
+ *
+ * \param chan The target wiimote.
+ * \param mode The mode used by the horizon tracking.
+ *
+ * \sa
+ * - `KPADGetHoriPlayMode()`
+ */
+void
+KPADSetHoriPlayMode(KPADChan chan,
+                    KPADPlayMode mode);
+
+/**
+ * Sets the MotionPlus acceleration correction parameters.
+ *
+ * \param chan The target wiimote.
+ * \param weight The weight parameter, in `[0, 1]`.
+ * \param range The range parameter, measured in g (Earth's gravity).
+ *
+ * \sa
+ * - `KPADGetMplsAccReviseParam()`
+ * - `KPADInitMplsAccReviseParam()`
+ */
+void
+KPADSetMplsAccReviseParam(KPADChan chan,
+                          float weight,
+                          float range);
+
+/**
+ * Sets the MotionPlus angles to arbitrary values.
+ *
+ * \note Angles are in normalized units: `1.0f` = 360°.
+ *
+ * \param chan The target wiimote.
+ * \param rx The pitch angle around the X axis.
+ * \param ry The yaw angle around the Y axis.
+ * \param rz The roll angle around the Z axis.
+ */
+void
+KPADSetMplsAngle(KPADChan chan,
+                 float rx,
+                 float ry,
+                 float rz);
+
+/**
+ * Sets the MotionPlus current computed directions.
+ *
+ * \param chan The target wiimote.
+ * \param dir The reference frame to copy to `KPADStatus::mplus::dir`.
+ */
+void
+KPADSetMplsDirection(KPADChan chan,
+                     const KPADBase3D *dir);
+
+/**
+ * Sets the MotionPlus velocity scale for computing directions.
+ *
+ * \param chan The target wiimote.
+ * \param scale The velocity scale used to integrate the directions. Default is `1`.
+ */
+void
+KPADSetMplsDirectionMag(KPADChan chan,
+                        float scale);
+
+/**
+ * Sets the MotionPlus reference frame that points at the TV.
+ *
+ * \param chan The target wiimote.
+ * \param base The base of the coordinate system that corresponds to pointing at the TV.
+ */
+void
+KPADSetMplsDirReviseBase(KPADChan chan,
+                         const KPADBase3D *base);
+
+/**
+ * Sets the MotionPlus direction correction weight parameter.
+ *
+ * \param chan The target wiimote.
+ * \param weight The weight parameter, in `[0, 1]`.
+ *
+ * - `KPADGetMplsDirReviseParam()`
+ * - `KPADInitMplsDirReviseParam()`
+ */
+void
+KPADSetMplsDirReviseParam(KPADChan chan,
+                          float weight);
+
+/**
+ * Sets the MotionPlus IR pointer correction weight parameter.
+ *
+ * \param chan The target wiimote.
+ * \param weight The weight parameter, in `[0, 1]`.
+ *
+ * \sa
+ * - `KPADGetMplsDpdReviseParam()`
+ * - `KPADInitMplsDpdReviseParam()`
+ */
+void
+KPADSetMplsDpdReviseParam(KPADChan chan,
+                          float weight);
+
+/**
+ * Sets the MotionPlus angular speed scales.
+ *
+ * \param chan The target wiimote.
+ * \param scale_pitch Scale applied to the pitch speed.
+ * \param scale_yaw Scale applied to the yaw speed.
+ * \param scale_roll Scale applied to the roll speed.
+ */
+void
+KPADSetMplsMagnification(KPADChan chan,
+                         float scale_pitch,
+                         float scale_yaw,
+                         float scale_roll);
+
+/**
+ * Sets the MotionPlus zero drift mode.
+ *
+ * \param chan The target wiimote.
+ * \param mode The zero drift mode.
+ *
+ * \sa
+ * - `KPADGetMplsZeroDriftMode()`
+ * - `KPADInitMplsZeroDriftMode()`
+ */
+void
+KPADSetMplsZeroDriftMode(KPADChan chan,
+                         KPADMplsZeroDriftMode mode);
+
+/**
+ * Sets the MotionPlus zero play tolerance.
+ *
+ * \param chan The target wiimote.
+ * \param tolerance The tolerance.
+ *
+ * \sa
+ * - `KPADGetMplsZeroPlayParam()`
+ * - `KPADInitMplsZeroPlayParam()`
+ */
+void
+KPADSetMplsZeroPlayParam(KPADChan chan,
+                         float tolerance);
+
+/**
+ * This function is stubbed, it does nothing.
+ */
+void
+KPADSetObjInterval(void);
+
+/**
+ * Sets the IR pointer's position parameters.
+ *
+ * \param chan The target wiimote.
+ * \param tolerance The tolerance, `>= 0`.
+ * \param sensitivity The sensitivity, in `[0, 1]`.
+ *
+ * \sa
+ * - `KPADGetPosParam()`
+ */
+void
+KPADSetPosParam(KPADChan chan,
+                float tolerance,
+                float sensitivity);
+
+/**
+ * Sets the IR pointer's position play mode.
+ *
+ * \note The default is `KPAD_PLAY_MODE_LOOSE`.
+ *
+ * \param chan The target wiimote.
+ * \param mode The position play mode.
+ *
+ * \sa
+ * - `KPADGetPosPlayMode()`
+ */
+void
+KPADSetPosPlayMode(KPADChan chan,
+                   KPADPlayMode mode);
+
+/**
+ * Sets the Nunchuk's pitch angle correction mode.
+ *
+ * \note
+ * This changes what it means for the Nunchuk to be upright:
+ * - Without correction, the neutral Nunchuk stick orientation is up.
+ * - With correction, laying the bottom flat on a surface is considered up.
+ *
+ * \param chan The target wiimote.
+ * \param correct Set to `TRUE` to apply angle correction.
+ *
+ * \sa
+ * - `KPADGetReviseAngle()`
+ * - `KPADReviseAcc()`
+ */
+void
+KPADSetReviseMode(KPADChan chan,
+                  BOOL correct);
+
+/**
+ * Sets the IR sensor bar's height.
+ *
+ * \param chan The target wiimote.
+ * \param height The set height.
+ *
+ * \sa
+ * - `KPADDisableAimingMode()`
+ * - `KPADEnableAimingMode()`
+ * - `KPADGetProjectionPos()`
+ * - `KPADGetSensorHeight()`
+ */
+void
+KPADSetSensorHeight(KPADChan chan,
+                    float height);
+
+/**
+ * Queues MotionPlus zero calibration.
+ *
+ * \note Calibration is performed inside `KPADRead()`.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADRead()`
+ * - `KPADStopMplsCalibration()`
+ * - `KPADWorkMplsCalibration()`
+ */
+void
+KPADStartMplsCalibration(KPADChan chan);
+
+/**
+ * Stops the MotionPlus calibration.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `KPADStartMplsCalibration()`
+ * - `KPADWorkMplsCalibration()`
+ */
+void
+KPADStopMplsCalibration(KPADChan chan);
+
+/**
+ * Returns progress of MotionPlus calibration.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return
+ * Progress of calibration, that decreases from `1.0` to `0.0`, or `< 0` when calibration
+ * is not active.
+ *
+ * \sa
+ * - `KPADStartMplsCalibration()`
+ * - `KPADStopMplsCalibration()`
+ */
+float
+KPADWorkMplsCalibration(KPADChan chan);
 
 #ifdef __cplusplus
 }

--- a/include/padscore/kpad.h
+++ b/include/padscore/kpad.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <wut.h>
-#include <padscore/wpad.h>
 #include <padscore/wbc.h>
+#include <padscore/wpad.h>
 
 /**
  * \defgroup padscore_kpad KPAD
@@ -50,7 +50,8 @@ typedef enum KPADButtonProcMode
 } KPADButtonProcMode;
 
 //! Status codes for `KPADControlDpdCallback`.
-typedef enum KPADControlDpdStatus {
+typedef enum KPADControlDpdStatus
+{
    KPAD_CONTROL_DPD_STATUS_STARTED  = 0,
    KPAD_CONTROL_DPD_STATUS_FINISHED = 1,
 } KPADControlDpdStatus;
@@ -87,13 +88,15 @@ typedef enum KPADControlMplsStatus
    KPAD_CONTROL_MPLS_STATUS_FAILED_MPLS_CLASSIC = -3,
 } KPADControlMplsStatus;
 
-typedef enum KPADMplsZeroDriftMode {
+typedef enum KPADMplsZeroDriftMode
+{
    KPAD_MPLS_ZERO_DRIFT_MODE_LOOSE,
    KPAD_MPLS_ZERO_DRIFT_MODE_STANDARD,
    KPAD_MPLS_ZERO_DRIFT_MODE_TIGHT,
 } KPADMplsZeroDriftMode;
 
-typedef enum KPADPlayMode {
+typedef enum KPADPlayMode
+{
    //! Use a smoothing filter.
    KPAD_PLAY_MODE_LOOSE = 0,
    //! Use a sharper, more responsive filter.
@@ -127,7 +130,8 @@ WUT_CHECK_OFFSET(KPADVec3D, 0x04, y);
 WUT_CHECK_OFFSET(KPADVec3D, 0x08, z);
 WUT_CHECK_SIZE(KPADVec3D, 0x0C);
 
-struct KPADBase3D {
+struct KPADBase3D
+{
    KPADVec3D x;
    KPADVec3D y;
    KPADVec3D z;
@@ -138,9 +142,10 @@ WUT_CHECK_OFFSET(KPADBase3D, 0x18, z);
 WUT_CHECK_SIZE(KPADBase3D, 0x24);
 
 //! 2D rectangle.
-struct KPADRect {
-   KPADVec2D top_left;
-   KPADVec2D bottom_right;
+struct KPADRect
+{
+   KPADVec2D topLeft;
+   KPADVec2D bottomRight;
 };
 WUT_CHECK_OFFSET(KPADRect, 0x00, top_left);
 WUT_CHECK_OFFSET(KPADRect, 0x08, bottom_right);

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -71,7 +71,8 @@ typedef enum WPADChan
    WPAD_CHAN_6 = 6,
 } WPADChan;
 
-typedef enum WPADClampType {
+typedef enum WPADClampType
+{
    WPAD_CLAMP_TYPE_OCTAGON_DEADZONE = 0,
    WPAD_CLAMP_TYPE_OCTAGON          = 1,
    WPAD_CLAMP_TYPE_CIRCLE_DEADZONE  = 2,
@@ -397,8 +398,9 @@ typedef enum WPADSensorBarPos
    WPAD_SENSOR_BAR_POS_ABOVE = 1,
 } WPADSensorBarPos;
 
-typedef enum WPADSyncDeviceEvent {
-   WPAD_SYNC_DEVICE_EVENT_STARTED = 0,
+typedef enum WPADSyncDeviceEvent
+{
+   WPAD_SYNC_DEVICE_EVENT_STARTED  = 0,
    WPAD_SYNC_DEVICE_EVENT_FINISHED = 1,
 } WPADSyncDeviceEvent;
 
@@ -767,7 +769,8 @@ struct WENCParams
 };
 WUT_CHECK_SIZE(WENCParams, 32);
 
-struct WPADiMplsCalibration {
+struct WPADiMplsCalibration
+{
    float pitchZero;
    float pitchScale;
 
@@ -1612,7 +1615,7 @@ WPADGetCLTriggerThreshold(WPADChan chan,
 
 void
 WPADGetDpdCornerPoints(WPADChan chan,
-                       void* dst);
+                       void *dst);
 
 uint8_t
 WPADGetDpdSensitivity(void);
@@ -1845,7 +1848,7 @@ WUDSerialFlashTestMode(void (*callback)(void));
 BOOL
 WUDSerialFlashTestRead(uint32_t unknown1,
                        uint8_t size,
-                       void (*callback)(void*, void*));
+                       void (*callback)(void *, void *));
 
 BOOL
 WUDSerialFlashTestWrite(uint32_t unknown1,

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -1519,27 +1519,6 @@ WPADControlBLC(WPADChan channel,
                WPADBalanceBoardCmd command,
                WPADCallback callback);
 
-/**
- * Called by `WPADInit()`.
- */
-void
-wpad_im_setup(void);
-
-void
-wpad_im_state_active(WPADChan chan);
-
-void
-wpad_im_state_home(uint32_t type, uint32_t unknown);
-
-void
-wpad_im_state_inactive(WPADChan chan);
-
-void
-wpad_im_state_power(void);
-
-void
-wpad_im_teardown(void);
-
 BOOL
 WPADAttachDummyExtension(WPADChan chan,
                          WPADExtensionType type);
@@ -1582,7 +1561,8 @@ void
 WPADDisableBluetooth(void);
 
 void
-WPADEnableSensorBar(BOOL enable);
+WPADEnableSensorBar(BOOL enable)
+   WUT_DEPRECATED("Use WPADSetSensorBar() instead.");
 
 BOOL
 WPADGetAcceptConnection(void);
@@ -1620,6 +1600,7 @@ WPADGetDpdCornerPoints(WPADChan chan,
 uint8_t
 WPADGetDpdSensitivity(void);
 
+//! Thisis a stub, it does nothing.
 WPADError
 WPADGetMPCalibration(void);
 
@@ -1739,7 +1720,8 @@ WPADRecalibrate(WPADChan chan);
 
 void
 WPADRegisterAllocator(const void *allocFunc,
-                      const void *freeFunc);
+                      const void *freeFunc)
+   WUT_DEPRECATED("This function is not used anymore.");
 
 void
 WPADRegisterBLCWorkarea(void);
@@ -1838,6 +1820,25 @@ WPADStartClearDevice(void);
 
 BOOL
 WPADStartFastSyncDevice(void);
+
+//! Called by `WPADInit()`.
+void
+wpad_im_setup(void);
+
+void
+wpad_im_state_active(WPADChan chan);
+
+void
+wpad_im_state_home(uint32_t type, uint32_t unknown);
+
+void
+wpad_im_state_inactive(WPADChan chan);
+
+void
+wpad_im_state_power(void);
+
+void
+wpad_im_teardown(void);
 
 uint16_t
 WUDGetFirmwareVersion(void);

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -22,6 +22,7 @@ typedef struct WPADVec2D WPADVec2D;
 typedef struct WPADVec3D WPADVec3D;
 typedef struct WPADInfo WPADInfo;
 typedef struct WPADAddress WPADAddress;
+typedef struct WPADiMplsCalibration WPADiMplsCalibration;
 typedef struct WPADiQueueElement WPADiQueueElement;
 typedef struct WPADiQueue WPADiQueue;
 typedef struct WPADIRDot WPADIRDot;
@@ -69,6 +70,13 @@ typedef enum WPADChan
    //! Channel 6.
    WPAD_CHAN_6 = 6,
 } WPADChan;
+
+typedef enum WPADClampType {
+   WPAD_CLAMP_TYPE_OCTAGON_DEADZONE = 0,
+   WPAD_CLAMP_TYPE_OCTAGON          = 1,
+   WPAD_CLAMP_TYPE_CIRCLE_DEADZONE  = 2,
+   WPAD_CLAMP_TYPE_CIRCLE           = 3,
+} WPADClampType;
 
 //! Data format.
 typedef enum WPADDataFormat
@@ -382,6 +390,17 @@ typedef enum WPADPeripheralSpace
    //! Infrared.
    WPAD_PERIPHERAL_SPACE_DPD        = 0xB0,
 } WPADPeripheralSpace;
+
+typedef enum WPADSensorBarPos
+{
+   WPAD_SENSOR_BAR_POS_BELOW = 0,
+   WPAD_SENSOR_BAR_POS_ABOVE = 1,
+} WPADSensorBarPos;
+
+typedef enum WPADSyncDeviceEvent {
+   WPAD_SYNC_DEVICE_EVENT_STARTED = 0,
+   WPAD_SYNC_DEVICE_EVENT_FINISHED = 1,
+} WPADSyncDeviceEvent;
 
 //! Balance Board commands.
 typedef enum WPADBalanceBoardCmd
@@ -748,6 +767,27 @@ struct WENCParams
 };
 WUT_CHECK_SIZE(WENCParams, 32);
 
+struct WPADiMplsCalibration {
+   float pitchZero;
+   float pitchScale;
+
+   float yawZero;
+   float yawScale;
+
+   float rollZero;
+   float rollScale;
+
+   int32_t degrees; // size 0x04, offset 0x18
+};
+WUT_CHECK_OFFSET(WPADiMplsCalibration, 0x00, pitchZero);
+WUT_CHECK_OFFSET(WPADiMplsCalibration, 0x04, pitchScale);
+WUT_CHECK_OFFSET(WPADiMplsCalibration, 0x08, yawZero);
+WUT_CHECK_OFFSET(WPADiMplsCalibration, 0x0C, yawScale);
+WUT_CHECK_OFFSET(WPADiMplsCalibration, 0x10, rollZero);
+WUT_CHECK_OFFSET(WPADiMplsCalibration, 0x14, rollScale);
+WUT_CHECK_OFFSET(WPADiMplsCalibration, 0x18, degrees);
+WUT_CHECK_SIZE(WPADiMplsCalibration, 0x1C);
+
 typedef void (*WPADCallback)(WPADChan channel, WPADError status);
 typedef WPADCallback WPADControlLedCallback;
 typedef WPADCallback WPADControlDpdCallback;
@@ -767,9 +807,12 @@ typedef void (*WPADSamplingCallback)(WPADChan channel);
  */
 typedef void (*WPADExtensionCallback)(WPADChan channel, WPADExtensionType ext);
 
+typedef void (*WPADClearDeviceCallback)(void*);
+
+typedef void (*WPADSyncDeviceCallback)(WPADSyncDeviceEvent event, WPADChan chan);
 
 /**
- * Initialises the WPAD library for use.
+ * Initializes the WPAD library for use.
  */
 void
 WPADInit(void);
@@ -1472,6 +1515,357 @@ WPADError
 WPADControlBLC(WPADChan channel,
                WPADBalanceBoardCmd command,
                WPADCallback callback);
+
+/**
+ * Called by `WPADInit()`.
+ */
+void
+wpad_im_setup(void);
+
+void
+wpad_im_state_active(WPADChan chan);
+
+void
+wpad_im_state_home(uint32_t type, uint32_t unknown);
+
+void
+wpad_im_state_inactive(WPADChan chan);
+
+void
+wpad_im_state_power(void);
+
+void
+wpad_im_teardown(void);
+
+BOOL
+WPADAttachDummyExtension(WPADChan chan,
+                         WPADExtensionType type);
+
+BOOL
+WPADCancelSyncDevice(void);
+
+void
+WPADClampAcc(WPADChan chan,
+             WPADStatus *status,
+             BOOL spherical);
+
+void
+WPADClampStick(WPADChan chan,
+               WPADStatus *status,
+               WPADClampType type);
+
+void
+WPADClampTrigger(WPADChan chan,
+                 WPADStatusClassic *status,
+                 BOOL type);
+
+WPADError
+WPADControlCustomDev(WPADExtensionType ext,
+                     BOOL unknown);
+
+
+WPADError
+WPADControlExtGimmick(WPADChan chan,
+                      uint32_t command,
+                      WPADCallback callback);
+
+BOOL
+WPADDeleteControllerOrder(void);
+
+BOOL
+WPADDetachDummyExtension(WPADChan chan);
+
+void
+WPADDisableBluetooth(void);
+
+void
+WPADEnableSensorBar(BOOL enable);
+
+BOOL
+WPADGetAcceptConnection(void);
+
+void
+WPADGetAccGravityUnit(WPADChan chan,
+                      WPADExtensionType ext,
+                      WPADVec3D *grav);
+
+uint32_t
+WPADGetAutoSleepTimeCount(WPADChan chan);
+
+WPADError
+WPADGetBLReg(WPADChan chan,
+             void *dst,
+             uint32_t address,
+             WPADCallback callback);
+
+void
+WPADGetCalibratedDPDObject(WPADIRDot *dst,
+                           const WPADIRDot *src);
+
+BOOL
+WPADGetCalibrationStatus(WPADChan chan);
+
+void
+WPADGetCLTriggerThreshold(WPADChan chan,
+                          uint8_t *left,
+                          uint8_t *right);
+
+void
+WPADGetDpdCornerPoints(WPADChan chan,
+                       void* dst);
+
+uint8_t
+WPADGetDpdSensitivity(void);
+
+WPADError
+WPADGetMPCalibration(void);
+
+uint8_t
+WPADGetRadioSensitivity(WPADChan chan);
+
+uint8_t
+WPADGetRegisteredDevNum(void);
+
+WPADSensorBarPos
+WPADGetSensorBarPosition(void);
+
+WPADError
+WPADGetSyncType(WPADChan chan,
+                uint8_t *type);
+
+WPADError
+WPADGetVSMCalibration(WPADChan chan,
+                      void *dst,
+                      uint32_t addr,
+                      uint32_t len,
+                      WPADCallback callback);
+
+WPADError
+WPADGetVSMInputSource(WPADChan chan,
+                      uint8_t *value,
+                      WPADCallback callback);
+
+WPADError
+WPADGetVSMLEDDrivePWMDuty(WPADChan chan,
+                          uint8_t *result,
+                          WPADCallback callback);
+
+WPADError
+WPADGetVSMPOT1State(WPADChan chan,
+                    uint8_t *state,
+                    WPADCallback callback);
+
+WPADError
+WPADGetVSMPOT2State(WPADChan chan,
+                    uint8_t *state,
+                    WPADCallback callback);
+
+uint32_t
+WPADGetWorkMemorySize(void);
+
+void
+WPADiClearMemBlock(WPADChan chan,
+                   void *wiimote_context);
+
+void
+WPADiControllerInfoInNand(void);
+
+void
+WPADiControlMpls(WPADChan chan,
+                 WPADMplsMode mode,
+                 WPADCallback callback);
+
+WPADError
+WPADiControlMplsProbe(WPADChan chan,
+                      uint8_t unknown);
+
+void
+WPADiCopyOut(WPADChan chan);
+
+void
+WPADiCreateKey(WPADChan chan);
+
+void
+WPADiCreateKeyFor3rd(WPADChan chan);
+
+void
+WPADiDecode(WPADChan chan,
+            void *buf,
+            uint16_t len,
+            uint16_t offset);
+
+void
+WPADiExcludeButton(WPADChan chan);
+
+void
+WPADiGetMplsCalibration(WPADChan chan,
+                        WPADiMplsCalibration *high,
+                        WPADiMplsCalibration *low);
+
+BOOL
+WPADiIsDummyExtension(WPADChan chan);
+
+
+BOOL
+WPADIsBusyForSync(void);
+
+BOOL
+WPADIsDpdEnabled(WPADChan chan);
+
+BOOL
+WPADIsEnabledCustomDev(WPADExtensionType ext);
+
+BOOL
+WPADIsEnabledWBC(void);
+
+void
+WPADiSetMplsCalibration(WPADChan chan,
+                        WPADStatusMotionPlus *status);
+
+BOOL
+WPADIsRegisteredBLC(void);
+
+BOOL
+WPADIsUsedCallbackByKPAD(void);
+
+BOOL
+WPADPurgeBtDb(void);
+
+void
+WPADRecalibrate(WPADChan chan);
+
+void
+WPADRegisterAllocator(const void *alloc_func,
+                      const void *free_func);
+
+void
+WPADRegisterBLCWorkarea(void);
+
+void
+WPADResetAutoSleepTimeCount(WPADChan chan);
+
+void
+WPADRestoreDpdData(uint32_t unknown1,
+                   uint32_t unknown2,
+                   BOOL ir_enabled,
+                   WPADChan chan);
+
+void
+WPADRestoreReportType(WPADChan chan,
+                      WPADDataFormat format,
+                      BOOL powerSave);
+
+WPADChan
+WPADRetrieveChannel(uint32_t unknown);
+
+BOOL
+WPADSaveConfig(void);
+
+BOOL
+WPADSetAcceptConnection(BOOL accept);
+
+
+WPADError
+WPADSetBLCalibration(void);
+
+WPADError
+WPADSetBLReg(WPADChan chan,
+             uint8_t value,
+             uint32_t addr,
+             WPADCallback callback);
+
+void
+WPADSetCallbackByKPAD(BOOL value);
+
+WPADClearDeviceCallback
+WPADSetClearDeviceCallback(WPADClearDeviceCallback callback);
+
+void
+WPADSetDisableChannelImm(uint8_t afhChannel);
+
+void
+WPADSetDpdSensitivity(uint8_t sensitivity);
+
+void
+WPADSetInactivePeriod(uint32_t period);
+
+WPADError
+WPADSetMPCalibration(void);
+
+void
+WPADSetRawDataBuffer(void);
+
+void
+WPADSetSensorBar(BOOL enable);
+
+void
+WPADSetSensorBarPosition(WPADSensorBarPos pos);
+
+void
+WPADSetSensorBarPower(BOOL enable);
+
+WPADSyncDeviceCallback
+WPADSetSyncDeviceCallback(WPADSyncDeviceCallback callback);
+
+WPADError
+WPADSetVSMCalibration(void);
+
+void
+WPADSetVSMInputSource(WPADChan chan,
+                      uint8_t value,
+                      WPADCallback callback);
+
+void
+WPADSetVSMLEDDrivePWMDuty(WPADChan chan,
+                          uint8_t unknown,
+                          WPADCallback callback);
+
+void
+WPADSetVSMPOT1State(WPADChan chan,
+                    uint8_t state,
+                    WPADCallback callback);
+
+void
+WPADSetVSMPOT2State(WPADChan chan,
+                    uint8_t state,
+                    WPADCallback callback);
+
+void
+WPADStartClearDevice(void);
+
+BOOL
+WPADStartFastSyncDevice(void);
+
+uint16_t
+WUDGetFirmwareVersion(void);
+
+BOOL
+WUDSerialFlashTestMode(void (*callback)(void));
+
+BOOL
+WUDSerialFlashTestRead(uint32_t unknown1,
+                       uint8_t size,
+                       void (*callback)(void*, void*));
+
+BOOL
+WUDSerialFlashTestWrite(uint32_t unknown1,
+                        uint8_t size,
+                        uint32_t unknown2,
+                        void (*callback)(void));
+
+BOOL
+WUDSerialFlashUpdate(void (*callback)(char, char));
+
+uint16_t
+WUDSerialFlashVersion(void);
+
+void
+WUDSetSniffMode(WPADAddress *btaddr,
+                void *unknown);
+
+void
+WUDSetVisibility(uint8_t unknown1,
+                 uint8_t unknown2);
 
 #ifdef __cplusplus
 }

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -777,7 +777,7 @@ struct WPADiMplsCalibration {
    float rollZero;
    float rollScale;
 
-   int32_t degrees; // size 0x04, offset 0x18
+   int32_t degrees;
 };
 WUT_CHECK_OFFSET(WPADiMplsCalibration, 0x00, pitchZero);
 WUT_CHECK_OFFSET(WPADiMplsCalibration, 0x04, pitchScale);
@@ -807,9 +807,9 @@ typedef void (*WPADSamplingCallback)(WPADChan channel);
  */
 typedef void (*WPADExtensionCallback)(WPADChan channel, WPADExtensionType ext);
 
-typedef void (*WPADClearDeviceCallback)(void*);
+typedef void (*WPADClearDeviceCallback)(uint32_t status);
 
-typedef void (*WPADSyncDeviceCallback)(WPADSyncDeviceEvent event, WPADChan chan);
+typedef void (*WPADSyncDeviceCallback)(WPADSyncDeviceEvent event, uint32_t unk);
 
 /**
  * Initializes the WPAD library for use.
@@ -1665,9 +1665,9 @@ WPADGetWorkMemorySize(void);
 
 void
 WPADiClearMemBlock(WPADChan chan,
-                   void *wiimote_context);
+                   void *wiimoteContext);
 
-void
+BOOL
 WPADiControllerInfoInNand(void);
 
 void
@@ -1735,8 +1735,8 @@ void
 WPADRecalibrate(WPADChan chan);
 
 void
-WPADRegisterAllocator(const void *alloc_func,
-                      const void *free_func);
+WPADRegisterAllocator(const void *allocFunc,
+                      const void *freeFunc);
 
 void
 WPADRegisterBLCWorkarea(void);
@@ -1747,7 +1747,7 @@ WPADResetAutoSleepTimeCount(WPADChan chan);
 void
 WPADRestoreDpdData(uint32_t unknown1,
                    uint32_t unknown2,
-                   BOOL ir_enabled,
+                   BOOL irEnabled,
                    WPADChan chan);
 
 void

--- a/include/padscore/wpad.h
+++ b/include/padscore/wpad.h
@@ -445,9 +445,9 @@ WUT_CHECK_SIZE(WPADVec3D, 0x06);
 //! A single IR dot tracked by the camera.
 struct WPADIRDot
 {
-   //! Position (in a 1024x768 grid).
+   //! Position (in a `1024x768` grid).
    WPADVec2D pos;
-   //! Pixel area (in a 128x96 grid).
+   //! Pixel area (in a `128x96` grid).
    uint16_t pixels;
    //! Identifier.
    uint8_t id;
@@ -461,13 +461,13 @@ WUT_CHECK_SIZE(WPADIRDot, 0x8);
 //! A single IR dot tracked by the camera, extra info.
 struct WPADIRDotEx
 {
-   //! Top-right coordinate (in a 1024x768 grid).
+   //! Top-right coordinate (in a `1024x768` grid).
    WPADVec2D topRight;
-   //! Bottom-left coordinate (in a 1024x768 grid).
+   //! Bottom-left coordinate (in a `1024x768` grid).
    WPADVec2D bottomLeft;
-   //! Pixel area (in a 128x96 grid).
+   //! Pixel area (in a `128x96` grid).
    uint16_t pixels;
-   //! Calculated size (from 0 to 15).
+   //! Calculated size (from `0` to `15`).
    uint8_t size;
    WUT_PADDING_BYTES(1);
 };
@@ -538,9 +538,9 @@ struct WPADStatusNunchuk
    WPADVec3D acc;
    struct
    {
-      //! x, in the range [-128, 127].
+      //! x, in the range `[-128, 127]`.
       int8_t x;
-      //! y, in the range [-128, 127].
+      //! y, in the range `[-128, 127]`.
       int8_t y;
    } stick;
 };
@@ -566,9 +566,9 @@ struct WPADStatusClassic
    WPADStatus core;
    //! Bitset from `WPADClassicButton`.
    uint16_t buttons;
-   //! Left stick: [-512, 511] x [-512, 511]
+   //! Left stick: `[-512, 511] x [-512, 511]`
    WPADVec2D leftStick;
-   //! Right stick: [-512, 511] x [-512, 511]
+   //! Right stick: `[-512, 511] x [-512, 511]`
    WPADVec2D rightStick;
    uint8_t leftTrigger;
    uint8_t rightTrigger;
@@ -593,9 +593,9 @@ struct WPADStatusProController
    WUT_PADDING_BYTES(2);
    //! Bitset from `WPADProButton`.
    uint32_t buttons;
-   //! Left stick: [-2048, 2047] x [-2048 x 2047]
+   //! Left stick: `[-2048, 2047] x [-2048 x 2047]`
    WPADVec2D leftStick;
-   //! Right stick: [-2048, 2047] x [-2048 x 2047]
+   //! Right stick: `[-2048, 2047] x [-2048 x 2047]`
    WPADVec2D rightStick;
    BOOL charging;
    BOOL wired;
@@ -629,9 +629,9 @@ struct WPADStatusMotionPlus
          WPADVec3D acc;
          struct
          {
-            //! x: [-128, 127]
+            //! x: `[-128, 127]`
             int8_t x;
-            //! y: [-128, 127]
+            //! y: `[-128, 127]`
             int8_t y;
          } stick;
       } nunchuk;
@@ -639,9 +639,9 @@ struct WPADStatusMotionPlus
       {
          //! Bitset from `WPADClassicButton`.
          uint16_t buttons;
-         //! Left stick: [-512, 511] x [-512, 511]
+         //! Left stick: `[-512, 511] x [-512, 511]`
          WPADVec2D leftStick;
-         //! Right stick: [-512, 511] x [-512, 511]
+         //! Right stick: `[-512, 511] x [-512, 511]`
          WPADVec2D rightStick;
          uint8_t leftTrigger;
          uint8_t rightTrigger;
@@ -762,7 +762,7 @@ struct WPADAddress
 WUT_CHECK_OFFSET(WPADAddress, 0x00, btDeviceAddress);
 WUT_CHECK_SIZE(WPADAddress, 0x6);
 
-//! Continuation parameters for \link WENCGetEncodeData
+//! Continuation parameters for `WENCGetEncodeData()`.
 struct WENCParams
 {
    WUT_UNKNOWN_BYTES(32);
@@ -1171,19 +1171,31 @@ WPADIsEnableWBC(void);
 void
 WPADEnableWiiRemote(BOOL enable);
 
+/**
+ * Sets how long the wiimote is kept connected while generating no new inputs.
+ *
+ * \param minutes Time timeout value, `0` to disable it. Default is `5` minutes.
+ *
+ * \sa
+ * - `WPADGetAutoSleepTimeCount()`
+ * - `WPADResetAutoSleepTimeCount()`
+ */
 void
-WPADSetAutoSleepTime(uint8_t time);
+WPADSetAutoSleepTime(uint8_t minutes);
 
 /**
- * Starts searching for a WPAD controller in pairing mode and syncs with it
- * \return TRUE if sync started
+ * Starts searching for a WPAD controller in pairing mode and syncs with it.
+ *
+ * \return TRUE if sync started.
  */
 BOOL
 WPADStartSyncDevice(void);
 
 /**
  * Starts attempts to sync with a WPAD with the specified properties.
- * If unable to find a device, does the same as \link WPADStartSyncDevice \endlink
+ *
+ * If unable to find a device, does the same as `WPADStartSyncDevice()`.
+ *
  * \param deviceAddress Bluetooth address of the device to connect to.
  * \param deviceName Bluetooth name of the device to connect to (up to 24 characters)
  * \return TRUE if sync started
@@ -1207,7 +1219,7 @@ WPADStartSyncDeviceEx(WPADAddress *deviceAddress,
  *   - `WPAD_ERROR_NO_CONTROLLER` when controller disconnects.
  * \return the previously used callback
  *
- * \warning May overwrite callbacks used internally by KPAD. If using KPAD, \link KPADSetConnectCallback \endlink is preferable.
+ * \warning May overwrite callbacks used internally by KPAD. If using KPAD, `KPADSetConnectCallback()` is preferable.
  */
 WPADConnectCallback
 WPADSetConnectCallback(WPADChan channel,
@@ -1249,7 +1261,7 @@ WPADGetLatestIndexInBuf(WPADChan channel);
  * Registers a callback to be invoked whenever new `WPADStatus*` data is stored in the
  * ring buffer.
  *
- * \warning May overwrite callbacks used internally by KPAD. If using KPAD, \link KPADSetSamplingCallback \endlink is preferable.
+ * \warning May overwrite callbacks used internally by KPAD. If using KPAD, `KPADSetSamplingCallback()` is preferable.
  *
  * \sa
  * - `WPADSetAutoSamplingBuf()`
@@ -1263,21 +1275,22 @@ void
 WPADiShutdown(void);
 
 /**
- * Clears all elements from queue
+ * Clears all elements from queue.
  */
 void
 WPADiClearQueue(WPADiQueue *queue);
 
 /**
- * Checks if there is enough space in the queue
+ * Checks if there is enough space in the queue.
  */
 bool
 WPADiIsAvailableCmdQueue(WPADiQueue *queue,
                          uint32_t count);
 
 /**
- * Parses incoming HID report data for a controller
- * \return -1 if first byte is outside the valid input report range (0x20 to 0x3f)
+ * Parses incoming HID report data for a controller.
+ *
+ * \return `-1` if first byte is outside the valid input report range (`0x20` to `0x3f`).
  */
 int32_t
 WPADiHIDParser(WPADChan channel,
@@ -1285,18 +1298,21 @@ WPADiHIDParser(WPADChan channel,
 
 
 /**
- * Queues HID Report for Rumble Update
+ * Queues HID Report for Rumble Update.
  *
- * Rumble must be set before this
- * \return TRUE if successfully added to queue
+ * Rumble must be set before this.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendSetVibrator(WPADiQueue *cmdQueue);
 
 /**
- * Queues HID Report for setting LEDs
- * used internally by \link WPADControlLed \endlink
- * \return TRUE if successfully added to queue
+ * Queues HID Report for setting LEDs.
+ *
+ * Used internally by `WPADControlLed()`.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendSetPort(WPADiQueue *cmdQueue,
@@ -1304,9 +1320,11 @@ WPADiSendSetPort(WPADiQueue *cmdQueue,
                  WPADCallback callback);
 
 /**
- * Queues HID Report for setting data reporting mode
- * used internally by \link WPADSetPowerSaveMode \endlink
- * \return TRUE if successfully added to queue
+ * Queues HID Report for setting data reporting mode.
+ *
+ * Used internally by `WPADSetPowerSaveMode()`.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendSetReportType(WPADiQueue *cmdQueue,
@@ -1315,9 +1333,11 @@ WPADiSendSetReportType(WPADiQueue *cmdQueue,
                        WPADCallback callback);
 
 /**
- * Queues HID report for a controller status request
- * used internally by \link WPADGetInfoAsync \endlink and several other functions
- * \return TRUE if successfully added to queue
+ * Queues HID report for a controller status request.
+ *
+ * Used internally by `WPADGetInfoAsync()` and several other functions.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendGetContStat(WPADiQueue *cmdQueue,
@@ -1325,9 +1345,11 @@ WPADiSendGetContStat(WPADiQueue *cmdQueue,
                      WPADCallback callback);
 
 /**
- * Queues HID Report for enabling the IR Camera clock
- * used internally by \link WPADControlDpd \endlink
- * \return TRUE if successfully added to queue
+ * Queues HID Report for enabling the IR Camera clock.
+ *
+ * Used internally by `WPADControlDpd`.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendEnableDPD(WPADiQueue *cmdQueue,
@@ -1335,9 +1357,11 @@ WPADiSendEnableDPD(WPADiQueue *cmdQueue,
                    WPADCallback callback);
 
 /**
- * Queues HID Report for enabling IR Camera
- * used internally by \link WPADControlDpd \endlink
- * \return TRUE if successfully added to queue
+ * Queues HID Report for enabling IR Camera.
+ *
+ * Used internally by `WPADControlDpd()`.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendEnableDPDCSB(WPADiQueue *cmdQueue,
@@ -1346,8 +1370,10 @@ WPADiSendEnableDPDCSB(WPADiQueue *cmdQueue,
 
 /**
  * Queues HID Report for enabling speakers.
- * Used internally by \link WPADControlSpeaker \link
- * \return TRUE if successfully added to queue
+ *
+ * Used internally by `WPADControlSpeaker()`.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendEnableSpeaker(WPADiQueue *cmdQueue,
@@ -1355,9 +1381,11 @@ WPADiSendEnableSpeaker(WPADiQueue *cmdQueue,
                        WPADCallback callback);
 
 /**
- * Queues HID Report for muting speakers
- * used internally by \link WPADControlSpeaker \link
- * \return TRUE if successfully added to queue
+ * Queues HID Report for muting speakers.
+ *
+ * Used internally by `WPADControlSpeaker()`.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendMuteSpeaker(WPADiQueue *cmdQueue,
@@ -1365,9 +1393,11 @@ WPADiSendMuteSpeaker(WPADiQueue *cmdQueue,
                      WPADCallback callback);
 
 /**
- * Queues HID Report for sending speaker stream data
- * used internally by \link WPADSendStreamData \endlink
- * \return TRUE if successfully added to queue
+ * Queues HID Report for sending speaker stream data.
+ *
+ * Used internally by `WPADSendStreamData()`.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendStreamData(WPADiQueue *cmdQueue,
@@ -1375,8 +1405,9 @@ WPADiSendStreamData(WPADiQueue *cmdQueue,
                     uint32_t size);
 
 /**
- * Queues HID Report for a single-byte memory write
- * \return TRUE if successfully added to queue
+ * Queues HID Report for a single-byte memory write.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendWriteDataCmd(WPADiQueue *cmdQueue,
@@ -1385,9 +1416,11 @@ WPADiSendWriteDataCmd(WPADiQueue *cmdQueue,
                       WPADCallback callback);
 
 /**
- * Queues HID Report for a multi-byte memory write
- * used internally by \link WPADWriteMemoryAsync \endlink
- * \return TRUE if successfully added to queue
+ * Queues HID Report for a multi-byte memory write.
+ *
+ * Used internally by `WPADWriteMemoryAsync()`.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendWriteData(WPADiQueue *cmdQueue,
@@ -1397,9 +1430,11 @@ WPADiSendWriteData(WPADiQueue *cmdQueue,
                    WPADCallback callback);
 
 /**
- * Queues HID Report for a memory read
- * used internally by \link WPADReadMemoryAsync \endlink
- * \return TRUE if successfully added to queue
+ * Queues HID Report for a memory read.
+ *
+ * Used internally by `WPADReadMemoryAsync()`.
+ *
+ * \return `TRUE` if successfully added to queue.
  */
 BOOL
 WPADiSendReadData(WPADiQueue *cmdQueue,
@@ -1409,66 +1444,73 @@ WPADiSendReadData(WPADiQueue *cmdQueue,
                   WPADCallback callback);
 
 /**
- * Game code (identifier), which may be saved to the EEPROM of connected controllers
- * \return pointer to the game code
+ * Gets game code (identifier), which may be saved to the EEPROM of connected controllers.
+ *
+ * \return pointer to the game code.
  */
 uint32_t *
 WPADiGetGameCode(void);
 
 /**
- * Game type, which may be saved to the EEPROM of connected controllers
- * \return 0x80
+ * Gets game type, which may be saved to the EEPROM of connected controllers.
+ *
+ * \return `0x80`
  */
 uint8_t
 WPADiGetGameType(void);
 
 /**
- * Sets game title for all connected controllers
- * \param title up to 17 UTF-16 characters including null terminator
- * title will be copied onto the controller EEPROM
+ * Sets game title for all connected controllers.
+ *
+ * \param title Up to 17 UTF-16 characters including null terminator, be copied onto the
+ *              controller EEPROM.
+ *
  * \sa
- * - WPADGetGameTitleUtf16
- * - WPADiWriteGameData
+ * - `WPADGetGameTitleUtf16()`
+ * - `WPADiWriteGameData()`
  */
 void
 WPADSetGameTitleUtf16(const uint16_t *title);
 
 /**
- * Gets game title stored on specified controller
+ * Gets game title stored on specified controller.
+ *
  * \param outTitle pointer to where the title will be output
  * \return `WPAD_ERROR_INVALID`, if game data previously failed to write
  * \sa
- * - WPADSetGameTitleUtf16
- * - WPADiReadGameData
+ * - `WPADSetGameTitleUtf16()`
+ * - `WPADiReadGameData()`
  */
 WPADError
 WPADGetGameTitleUtf16(WPADChan channel,
                       uint16_t **outTitle);
 
 /**
- * Get the time that game data was written
- * \return `WPAD_ERROR_INVALID`, if game data previously failed to write
+ * Gets the time that game data was written.
+ *
+ * \return `WPAD_ERROR_INVALID`, if game data previously failed to write.
  */
 WPADError
 WPADGetGameDataTimeStamp(WPADChan channel,
                          OSTime *outTimestamp);
 
 /**
- * Write custom game data to the controller's EEPROM
+ * Writes custom game data to the controller's EEPROM.
  *
  * \param offset start address within custom data region
  * \param callback Invoked when write completes; status will be:
  *   - `WPAD_ERROR_NONE` on success.
  *   - `WPAD_ERROR_TRANSFER` on failure.
  *
- * also stores the current game type and game code and commits the game title set by \link WPADSetGameTitleUtf16 \endlink
+ * Also stores the current game type and game code and commits the game title set by `WPADSetGameTitleUtf16()`.
+ *
  * \return `WPAD_ERROR_NONE`, if the write request was sent
  * \return `WPAD_ERROR_NOT_READY`, if the controller is busy, or game data is in the process of being read or written
  * \sa
- * - WPADiReadGameData
- * - WPADiGetGameType
- * - WPADiGetGameCode
- * - WPADGetGameDataTimestamp
+ * - `WPADiReadGameData()`
+ * - `WPADiGetGameType()`
+ * - `WPADiGetGameCode()`
+ * - `WPADGetGameDataTimeStamp()`
  */
 WPADError
 WPADiWriteGameData(WPADChan channel,
@@ -1478,15 +1520,16 @@ WPADiWriteGameData(WPADChan channel,
                    WPADCallback callback);
 
 /**
- * Read custom game data from the controller's EEPROM
+ * Reads custom game data from the controller's EEPROM.
+ *
  * \param offset start address within custom data region
  * \return `WPAD_ERROR_NONE`, if the read request was sent
  * \return `WPAD_ERROR_NOT_READY`, if the controller's game data is in the process of being read or written
  * \return `WPAD_ERROR_PERMISSION`, if the WPAD's GameCode does not match the global Game Code
  * \return `WPAD_ERROR_BROKEN`, if game data previously failed to write
  * \sa
- * - WPADiWriteGameData
- * - WPADiGetGameCode
+ * - `WPADiWriteGameData()`
+ * - `WPADiGetGameCode()`
  */
 WPADError
 WPADiReadGameData(WPADChan channel,
@@ -1496,7 +1539,7 @@ WPADiReadGameData(WPADChan channel,
                   WPADCallback callback);
 
 /**
- * Get MotionPlus mode
+ * Gets MotionPlus mode
  *
  * identical to \link KPADGetMplsStatus \endlink
  */
@@ -1506,7 +1549,7 @@ WPADiGetMplsStatus(void);
 /**
  * Returns the battery level.
  *
- * \return A charge level, from 0 to 4.
+ * \return A charge level, from `0` to `4`.
  */
 uint8_t
 WPADGetBatteryLevel(WPADChan channel);
@@ -1572,6 +1615,19 @@ WPADGetAccGravityUnit(WPADChan chan,
                       WPADExtensionType ext,
                       WPADVec3D *grav);
 
+/**
+ * Gets the time since last input activity on a specific wiimote.
+ *
+ * \note This timer is updated even when auto sleep is disabled.
+ *
+ * \param chan The target wiimote.
+ *
+ * \return The current auto sleep timer, in milliseconds.
+ *
+ * \sa
+ * - `WPADResetAutoSleepTimeCount()`
+ * - `WPADSetAutoSleepTime()`
+ */
 uint32_t
 WPADGetAutoSleepTimeCount(WPADChan chan);
 
@@ -1726,6 +1782,15 @@ WPADRegisterAllocator(const void *allocFunc,
 void
 WPADRegisterBLCWorkarea(void);
 
+/**
+ * Resets the auto sleep timer back to zero.
+ *
+ * \param chan The target wiimote.
+ *
+ * \sa
+ * - `WPADGetAutoSleepTimeCount()`
+ * - `WPADSetAutoSleepTime()`
+ */
 void
 WPADResetAutoSleepTimeCount(WPADChan chan);
 
@@ -1829,7 +1894,8 @@ void
 wpad_im_state_active(WPADChan chan);
 
 void
-wpad_im_state_home(uint32_t type, uint32_t unknown);
+wpad_im_state_home(uint32_t type,
+                   uint32_t unknown);
 
 void
 wpad_im_state_inactive(WPADChan chan);
@@ -1839,37 +1905,6 @@ wpad_im_state_power(void);
 
 void
 wpad_im_teardown(void);
-
-uint16_t
-WUDGetFirmwareVersion(void);
-
-BOOL
-WUDSerialFlashTestMode(void (*callback)(void));
-
-BOOL
-WUDSerialFlashTestRead(uint32_t unknown1,
-                       uint8_t size,
-                       void (*callback)(void *, void *));
-
-BOOL
-WUDSerialFlashTestWrite(uint32_t unknown1,
-                        uint8_t size,
-                        uint32_t unknown2,
-                        void (*callback)(void));
-
-BOOL
-WUDSerialFlashUpdate(void (*callback)(char, char));
-
-uint16_t
-WUDSerialFlashVersion(void);
-
-void
-WUDSetSniffMode(WPADAddress *btaddr,
-                void *unknown);
-
-void
-WUDSetVisibility(uint8_t unknown1,
-                 uint8_t unknown2);
 
 #ifdef __cplusplus
 }

--- a/include/padscore/wud.h
+++ b/include/padscore/wud.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <wut.h>
+#include <padscore/wpad.h>
+
+/**
+ * \defgroup padscore_wud WUD
+ * \ingroup padscore
+ *
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint16_t
+WUDGetFirmwareVersion(void);
+
+BOOL
+WUDSerialFlashTestMode(void (*callback)(void));
+
+BOOL
+WUDSerialFlashTestRead(uint32_t unknown1,
+                       uint8_t size,
+                       void (*callback)(void *, void *));
+
+BOOL
+WUDSerialFlashTestWrite(uint32_t unknown1,
+                        uint8_t size,
+                        uint32_t unknown2,
+                        void (*callback)(void));
+
+BOOL
+WUDSerialFlashUpdate(void (*callback)(char, char));
+
+uint16_t
+WUDSerialFlashVersion(void);
+
+void
+WUDSetSniffMode(WPADAddress *btaddr,
+                void *unknown);
+
+void
+WUDSetVisibility(uint8_t unknown1,
+                 uint8_t unknown2);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/tests/test_compile_headers_common/test_compile_headers_list.h
+++ b/tests/test_compile_headers_common/test_compile_headers_list.h
@@ -159,6 +159,7 @@
 #include <padscore/kpad.h>
 #include <padscore/wbc.h>
 #include <padscore/wpad.h>
+#include <padscore/wud.h>
 #include <proc_ui/memory.h>
 #include <proc_ui/procui.h>
 #include <sndcore2/core.h>


### PR DESCRIPTION
This adds declarations for all padscore functions listed in `padscore.def`, even the stubs.

- Added all WPAD functions.
- Added all KPAD functions, and documentation.
- Changed KPADStatus::mplus to have all directions in a KPADBase3D struct.

The functions I could not figure out entirely, I just made sure the arguments match the usage in the implementation, through ghidra.