### PR TITLE
coreinit/debug: Add documentation to the functions that kill the console

### DIFF
--- a/include/coreinit/debug.h
+++ b/include/coreinit/debug.h
@@ -41,8 +41,11 @@ typedef enum OSFatalErrorMessageType
 struct OSFatalError
 {
    OSFatalErrorMessageType messageType;
+   //! Error code, displayed on screen as unsigned, and printed in log as signed
    uint32_t errorCode;
+   //! See \link OSGetUPID \endlink
    uint32_t processId;
+   //! Internal error code printed in log
    uint32_t internalErrorCode;
    uint32_t line;
    char functionName[64];
@@ -83,7 +86,12 @@ void
 OSReportWarn(const char *fmt, ...)
    WUT_FORMAT_PRINTF(1, 2);
 
-
+/**
+ * Halts the system and logs the cause, traps if debugger is present
+ * \param file name of the file where the panic occurred
+ * \param line position in the file where the panic occurred
+ * \param fmt printf-style format string for logging
+ */
 void
 OSPanic(const char *file,
         uint32_t line,
@@ -91,10 +99,22 @@ OSPanic(const char *file,
         ...)
    WUT_FORMAT_PRINTF(3, 4);
 
-
+/**
+ * Displays a message on TV and gamepad screens via OSScreen, and halts the system via \link OSPanic \endlink
+ * \param msg message to be displayed and logged
+ * \sa coreinit_screen
+ */
 void
 OSFatal(const char *msg);
 
+/**
+ * Switch to the fatal error process ("An error has occured." screen)
+ * \param error structure describing the error
+ * \param functionName function name printed in log
+ * \param line line number printed in log
+ *
+ * The fatal error process displays the error code, firmware version, Wii U model, serial number and status code
+ */
 void
 OSSendFatalError(OSFatalError *error,
                  const char *functionName,

--- a/include/coreinit/debug.h
+++ b/include/coreinit/debug.h
@@ -100,7 +100,7 @@ OSPanic(const char *file,
         uint32_t line,
         const char *fmt,
         ...)
-   WUT_FORMAT_PRINTF(3, 4) WUT_NORETURN;
+   WUT_FORMAT_PRINTF(3, 4);
 
 /**
  * Set a callback to be triggered when an \link OSPanic \endlink occurs
@@ -116,7 +116,7 @@ OSSetPanicCallback(OSPanicCallback callback,
  * \sa coreinit_screen
  */
 void
-OSFatal(const char *msg) WUT_NORETURN;
+OSFatal(const char *msg);
 
 /**
  * Switch to the fatal error process ("An error has occured." screen)
@@ -129,7 +129,7 @@ OSFatal(const char *msg) WUT_NORETURN;
 void
 OSSendFatalError(OSFatalError *error,
                  const char *functionName,
-                 uint32_t line) WUT_NORETURN;
+                 uint32_t line);
 
 uint32_t
 OSGetSymbolName(uint32_t addr,

--- a/include/coreinit/debug.h
+++ b/include/coreinit/debug.h
@@ -16,6 +16,7 @@ typedef struct OSFatalError OSFatalError;
 typedef void (*DisassemblyPrintFn)(const char *fmt, ...);
 
 typedef uint32_t (*DisassemblyFindSymbolFn)(uint32_t addr, char *symbolNameBuf, uint32_t symbolNameBufSize);
+typedef void (*OSPanicCallback)(void *userData);
 
 typedef enum DisassemblePPCFlags
 {
@@ -91,6 +92,8 @@ OSReportWarn(const char *fmt, ...)
  * \param file name of the file where the panic occurred
  * \param line position in the file where the panic occurred
  * \param fmt printf-style format string for logging
+ *
+ * \sa OSSetPanicCallback
  */
 void
 OSPanic(const char *file,
@@ -98,6 +101,14 @@ OSPanic(const char *file,
         const char *fmt,
         ...)
    WUT_FORMAT_PRINTF(3, 4) WUT_NORETURN;
+
+/**
+ * Set a callback to be triggered when an \link OSPanic \endlink occurs
+ * \param userData data to pass to the callback
+ */
+void
+OSSetPanicCallback(OSPanicCallback callback,
+                   void *userData);
 
 /**
  * Displays a message on TV and gamepad screens via OSScreen, and halts the system via \link OSPanic \endlink

--- a/include/coreinit/debug.h
+++ b/include/coreinit/debug.h
@@ -97,7 +97,7 @@ OSPanic(const char *file,
         uint32_t line,
         const char *fmt,
         ...)
-   WUT_FORMAT_PRINTF(3, 4);
+   WUT_FORMAT_PRINTF(3, 4) WUT_NORETURN;
 
 /**
  * Displays a message on TV and gamepad screens via OSScreen, and halts the system via \link OSPanic \endlink
@@ -105,7 +105,7 @@ OSPanic(const char *file,
  * \sa coreinit_screen
  */
 void
-OSFatal(const char *msg);
+OSFatal(const char *msg) WUT_NORETURN;
 
 /**
  * Switch to the fatal error process ("An error has occured." screen)
@@ -118,7 +118,7 @@ OSFatal(const char *msg);
 void
 OSSendFatalError(OSFatalError *error,
                  const char *functionName,
-                 uint32_t line);
+                 uint32_t line) WUT_NORETURN;
 
 uint32_t
 OSGetSymbolName(uint32_t addr,

--- a/include/wut.h
+++ b/include/wut.h
@@ -10,6 +10,7 @@
 
 #define WUT_DEPRECATED(reason)       __attribute__((__deprecated__(reason)))
 #define WUT_FORMAT_PRINTF(fmt, args) __attribute__((__format__(__printf__, fmt, args)))
+#define WUT_NORETURN __attribute__((noreturn))
 
 #else // not __GNUC__ and not __clang__
 

--- a/include/wut.h
+++ b/include/wut.h
@@ -10,7 +10,6 @@
 
 #define WUT_DEPRECATED(reason)       __attribute__((__deprecated__(reason)))
 #define WUT_FORMAT_PRINTF(fmt, args) __attribute__((__format__(__printf__, fmt, args)))
-#define WUT_NORETURN __attribute__((noreturn))
 
 #else // not __GNUC__ and not __clang__
 


### PR DESCRIPTION
I'd like to also remove `line` and `functionName` in `OSFatalError`, because I couldn't find them being used, but I'll leave it for now.

I also am unsure whether to add the `noreturn` attribute to the functions