### PR TITLE
gx2: Add GX2GetLastFrame, GX2GetLastFrameGamma documentation

### DIFF
--- a/include/gx2/swap.h
+++ b/include/gx2/swap.h
@@ -22,10 +22,34 @@ GX2CopyColorBufferToScanBuffer(const GX2ColorBuffer *buffer,
 void
 GX2SwapScanBuffers();
 
+/**
+ * Gets the last frame displayed before exiting foreground.
+ * This can be used for transition effects with the splash.
+ * 
+ * \param scanTarget
+ * The scan-target to source from.
+ * 
+ * \param texture 
+ * A pointer to the texture to store the frame. The resulting surface format is #GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8.
+ *
+ * \sa
+ * - GX2GetLastFrameGamma()
+ */
 BOOL
 GX2GetLastFrame(GX2ScanTarget scanTarget,
                 GX2Texture *texture);
 
+/**
+ * Gets the gamma of the last frame displayed before exiting foreground.
+ * \param scanTarget
+ * The scan-target to source from.
+ * 
+ * \param gammaOut 
+ * A pointer to store the gamma.
+ *
+ * \sa
+ * - GX2GetLastFrame()
+ */
 BOOL
 GX2GetLastFrameGamma(GX2ScanTarget scanTarget,
                      float *gammaOut);

--- a/include/gx2/swap.h
+++ b/include/gx2/swap.h
@@ -30,7 +30,7 @@ GX2SwapScanBuffers();
  * The scan-target to source from.
  * 
  * \param texture 
- * A pointer to the texture to store the frame. The resulting surface format is #GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8.
+ * A pointer to store the texture of the last frame. The resulting surface format is #GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8.
  *
  * \sa
  * - GX2GetLastFrameGamma()


### PR DESCRIPTION
I mainly did this to document the surface format, which is GX2_SURFACE_FORMAT_SRGB_R8_G8_B8_A8.